### PR TITLE
Updates to gradle build file and GitHub workflow

### DIFF
--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -1,9 +1,6 @@
 name: Java CI
 
 on: 
-  push: 
-    branches: 
-      - '*'
   pull_request:
     branches: 
       - '*'

--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -3,73 +3,78 @@ name: Java CI
 on: 
   push: 
     branches: 
-      - main
+      - '*'
   pull_request:
     branches: 
-      - main
+      - '*'
 
 jobs:
   build_rca_pkg:
+    strategy:
+      matrix:
+        java: [12]
+
     runs-on: [ubuntu-latest]
-    name: Building RCA package
+    name: Building Performance Analyzer package
+
     steps:
-    - name: Checkout RCA package
-      uses: actions/checkout@v2
-      with:
-        repository: opensearch-project/performance-analyzer-rca
-        path: ./tmp/rca
-    - name: Checkout Performance Analyzer package
-      uses: actions/checkout@v2
-      with:
-        path: ./tmp/pa
+      - name: Set up JDK ${{ matrix.java }}
+        uses: actions/setup-java@v1
+        with:
+          java-version: ${{ matrix.java }}
+
+      - name: Checkout Performance Analyzer
+        uses: actions/checkout@v2
+
+      - name: Checkout OpenSearch
+        uses: actions/checkout@v2
+        with:
+          repository: 'opensearch-project/OpenSearch'
+          path: OpenSearch
+          ref: '1.0.0-beta1'
+
+      - name: Build OpenSearch
+        working-directory: ./OpenSearch
+        run: ./gradlew publishToMavenLocal -Dbuild.version_qualifier=beta1 -Dbuild.snapshot=false -x test --info
+
+      - name: Checkout RCA
+        uses: actions/checkout@v2
+        with:
+          repository: 'opensearch-project/performance-analyzer-rca'
+          path: performance-analyzer-rca
+
+      - name: Build RCA
+        working-directory: ./performance-analyzer-rca
+        run: ./gradlew publishToMavenLocal -x test --info
+
       # fetch the main branch to make it available for spotless ratcheting
-    - name: Fetch 'main' branch
-      working-directory:  ./tmp/pa
-      run: git fetch --depth=1 origin main
-    - name: Set up JDK 1.12
-      uses: actions/setup-java@v1
-      with:
-        java-version: 1.12
-    - name: Build RCA with Gradle
-      working-directory:  ./tmp/rca
-      run: ./gradlew build -x test
-    - name: Publish RCA jar to maven local
-      working-directory: ./tmp/rca
-      run: ./gradlew publishToMavenLocal
-    # dependencies: OpenSearch
-    - name: Checkout OpenSearch
-      uses: actions/checkout@v2
-      with:
-        repository: 'opensearch-project/OpenSearch'
-        path: OpenSearch
-        ref: '1.0.0-beta1'
-    - name: Build OpenSearch
-      working-directory: ./OpenSearch
-      run: ./gradlew publishToMavenLocal -Dbuild.version_qualifier=beta1 -Dbuild.snapshot=false
-    - name: Build PA gradle using the new RCA jar
-      working-directory: ./tmp/pa
-      run: rm -f licenses/performanceanalyzer-rca-1.0.0.0-beta1.jar.sha1
-    - name: Update SHA
-      working-directory: ./tmp/pa
-      run: ./gradlew updateShas
+      - name: Fetch Performance Analyzer 'main' branch
+        run: git fetch --depth=1 origin main
+
+      - name: Update Performance Analyzer SHA for current build
+        run: |
+          rm -f licenses/performanceanalyzer-rca-1.0.0.0-beta1.jar.sha1
+          ./gradlew updateShas --info
+
       # Explicitly set the docker-compose program path so that our build scripts in RCA can run the program
       # This is necessary because of the Github Actions environment and the workingDir of the Gradle environment
-    - name: Set docker-compose path
-      run: DOCKER_COMPOSE_LOCATION=$(which docker-compose)
+      - name: Set docker-compose path
+        run: DOCKER_COMPOSE_LOCATION=$(which docker-compose)
+
       # Set the vm.max_map_count system property to the minimum required to run OpenSearch
-    - name: Set vm.max_map_count
-      run: sudo sysctl -w vm.max_map_count=262144
-    - name: Build PA and run Unit Tests
-      working-directory: ./tmp/pa
-      run: ./gradlew build
-    - name: Generate Jacoco coverage report
-      working-directory: ./tmp/pa
-      run: ./gradlew jacocoTestReport
-    - name: Upload coverage report
-      working-directory: ./tmp/pa
-      env:
-        CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
-      run: bash <(curl -s https://codecov.io/bash) -f ./build/reports/jacoco/test/jacocoTestReport.xml
-    - name: Run Integration Tests
-      working-directory: ./tmp/pa
-      run: ./gradlew integTest -Dtests.enableIT -Dtests.useDockerCluster
+      - name: Set vm.max_map_count
+        run: sudo sysctl -w vm.max_map_count=262144
+
+      - name: Build Performance Analyzer
+        run: ./gradlew build -PrcaProjectDir=./performance-analyzer-rca --info --stacktrace
+
+      - name: Generate Jacoco coverage report
+        run: ./gradlew jacocoTestReport --info
+
+      - name: Upload coverage report
+        env:
+          CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
+        run: bash <(curl -s https://codecov.io/bash) -f ./build/reports/jacoco/test/jacocoTestReport.xml
+
+      - name: Run Integration Tests
+        run: ./gradlew integTest -Dtests.enableIT=true -Dtests.useDockerCluster=true --info

--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -73,5 +73,9 @@ jobs:
           CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
         run: bash <(curl -s https://codecov.io/bash) -f ./build/reports/jacoco/test/jacocoTestReport.xml
 
-      - name: Run Integration Tests
+      - name: Spin up Docker cluster for integration testing
+        working-directory: ./performance-analyzer-rca
+        run: ./gradlew enableRca --info
+
+      - name: Run integration tests
         run: ./gradlew integTest -Dtests.enableIT=true -Dtests.useDockerCluster=true --info

--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -56,7 +56,7 @@ jobs:
       # Explicitly set the docker-compose program path so that our build scripts in RCA can run the program
       # This is necessary because of the Github Actions environment and the workingDir of the Gradle environment
       - name: Set docker-compose path
-        run: DOCKER_COMPOSE_LOCATION=$(which docker-compose)
+        run: echo "DOCKER_COMPOSE_LOCATION=$(which docker-compose)" >> $GITHUB_ENV
 
       # Set the vm.max_map_count system property to the minimum required to run OpenSearch
       - name: Set vm.max_map_count

--- a/build.gradle
+++ b/build.gradle
@@ -25,11 +25,12 @@
  */
 
 buildscript {
-
     ext {
+        opensearch_group = "org.opensearch"
         opensearch_version = System.getProperty("opensearch.version", "1.0.0-beta1")
     }
-    // This isn't applying from repositories.gradle so repeating it here
+
+    // Used to resolve build file dependencies
     repositories {
         mavenCentral()
         mavenLocal()
@@ -38,7 +39,7 @@ buildscript {
     }
 
     dependencies {
-        classpath "org.opensearch.gradle:build-tools:${opensearch_version}"
+        classpath "${opensearch_group}.gradle:build-tools:${opensearch_version}-SNAPSHOT"
         classpath 'org.ajoberstar:gradle-git:0.2.3'
     }
 }
@@ -49,6 +50,20 @@ plugins {
     id 'com.github.spotbugs' version '4.6.0'
     id 'jacoco'
     id 'com.diffplug.spotless' version '5.11.0'
+}
+
+ext {
+    performanceAnalyzerVersion = '1.0.0'
+    isSnapshot = "true" == System.getProperty("build.snapshot", "true")
+
+    // Name of the default git branch. This is used for spotless ratcheting and for checking out the RCA repository
+    gitDefaultBranch = 'main'
+
+    // If true, then the build will clone the RCA Project into $rcaProjectDir
+    cloneRcaProject = findProperty("cloneRcaProject") == "true"
+
+    // By default we will look for RCA in a peer directory
+    rcaProjectDir = findProperty("rcaProjectDir") ?: "../performance-analyzer-rca"
 }
 
 spotbugsMain {
@@ -66,25 +81,16 @@ spotbugsTest {
     ignoreFailures = true
 }
 
-ext {
-    opensearchVersion = '1.0.0'
-    isSnapshot = "true" == System.getProperty("build.snapshot", "true")
-}
-
 group = "org.opensearch"
-version = "${opensearchVersion}.0-beta1"
+version = "${performanceAnalyzer}.0-beta1"
 if (isSnapshot) {
     version += "-SNAPSHOT"
 }
 
 apply plugin: 'opensearch.opensearchplugin'
 
-ext {
-    projectSubstitutions = [:]
-    licenseFile = rootProject.file('LICENSE.txt')
-    noticeFile = rootProject.file('NOTICE.txt')
-    gitDefaultBranch = 'main'
-}
+licenseFile = rootProject.file('LICENSE.txt')
+noticeFile = rootProject.file('NOTICE.txt')
 
 spotless {
     java {
@@ -110,8 +116,6 @@ test {
 
 licenseHeaders.enabled = false
 validateNebulaPom.enabled = false
-
-
 loggerUsageCheck.enabled = false
 
 opensearchplugin {
@@ -154,7 +158,6 @@ repositories {
     maven { url "https://plugins.gradle.org/m2/" }
     jcenter()
 }
-
 
 configurations {
     includeJars
@@ -209,7 +212,6 @@ jacocoTestCoverageVerification {
         }
     }
 }
-
 
 // to run coverage verification during the build (and fail when appropriate)
 check.dependsOn jacocoTestCoverageVerification
@@ -299,12 +301,9 @@ gradle.startParameter.excludedTaskNames += [ "forbiddenApisMain",
                                              "forbiddenApisTest",
                                              "thirdPartyAudit",
                                              "testingConventions"]
-import java.nio.file.Paths
+
 import org.ajoberstar.gradle.git.tasks.GitClone
 import org.opensearch.gradle.test.RestIntegTestTask
-
-String rcaDir
-String rcaArtifactsDir
 
 static def propEnabled(property) {
     return System.getProperty(property) != null && System.getProperty(property).toLowerCase().equals("true")
@@ -312,35 +311,44 @@ static def propEnabled(property) {
 
 // The following Gradle tasks are used to create a PA/RCA enabled OpenSearch cluster
 // Pass the -Dtests.enableIT property to Gradle to run ITs
+
 /**
  * cloneGitRepo clones the performance-analyzer-rca repo if the -Dtests.enableIT=true flag is passed
  * to the Gradle JVM
  */
 task cloneGitRepo(type: GitClone) {
-    rcaDir = Paths.get(getProject().getBuildDir().toString(), "performance-analyzer-rca").toString()
-    def destination = file(rcaDir)
+    def destination = file(rcaProjectDir)
     uri = "https://github.com/opensearch-project/performance-analyzer-rca.git"
     branch = gitDefaultBranch
     destinationPath = destination
     bare = false
-    enabled = !destination.exists() // to clone only once
+    enabled = cloneRcaProject && !destination.exists() // to clone only once
+
+    doFirst {
+        logger.info("Cloning performance-analyzer-rca into ${rcaProjectDir}")
+    }
 }
 
 task buildRca() {
     dependsOn(cloneGitRepo)
+
+    doFirst {
+        logger.info("Building performance-analyzer-rca project in ${rcaProjectDir}")
+    }
+
     doLast {
         exec {
-            workingDir("$rcaDir")
+            workingDir("$rcaProjectDir")
             commandLine './gradlew', 'build', '-x', 'test'
         }
         exec {
-            workingDir("$rcaDir")
+            workingDir("$rcaProjectDir")
             commandLine './gradlew', 'publishToMavenLocal'
         }
         exec {
             def licenseDir = "$projectDir/licenses"
             workingDir("$licenseDir")
-            commandLine 'rm', "performanceanalyzer-rca-1.0.0.0-beta1.jar.sha1"
+            commandLine 'rm', "-f", "performanceanalyzer-rca-1.0.0.0-beta1.jar.sha1"
         }
         exec {
             workingDir("$projectDir")
@@ -349,16 +357,23 @@ task buildRca() {
     }
 }
 
+// This value is set by the unpackRca task
+def rcaArtifactsDir
+
 task unpackRca(type: Copy) {
     dependsOn(buildRca)
-    from(zipTree("$rcaDir/build/distributions/performance-analyzer-rca.zip")) {
+    from(zipTree("$rcaProjectDir/build/distributions/performance-analyzer-rca.zip")) {
     }
-    into "$rcaDir/build/distributions"
-    rcaArtifactsDir = "$rcaDir/build/distributions/performance-analyzer-rca/"
+    into "$rcaProjectDir/build/distributions"
+    rcaArtifactsDir = "$rcaProjectDir/build/distributions/performance-analyzer-rca/"
+
+    doLast {
+        logger.info("Unpacked performance-analyzer-rca artifacts into ${rcaProjectDir}")
+    }
 }
 
 bundlePlugin {
-    dependsOn 'cloneGitRepo'
+    dependsOn 'unpackRca'
     from("$rcaArtifactsDir/pa_config") {
         into "pa_config"
     }
@@ -401,7 +416,7 @@ task setupOpenSearchCluster() {
     }
     doLast {
         exec {
-            workingDir(rcaDir)
+            workingDir(rcaProjectDir)
             commandLine './gradlew', 'enableRca'
         }
         sleep(30000)
@@ -529,4 +544,3 @@ afterEvaluate {
 }
 
 bundlePlugin.mustRunAfter unpackRca
-build.dependsOn unpackRca

--- a/build.gradle
+++ b/build.gradle
@@ -39,7 +39,7 @@ buildscript {
     }
 
     dependencies {
-        classpath "${opensearch_group}.gradle:build-tools:${opensearch_version}-SNAPSHOT"
+        classpath "${opensearch_group}.gradle:build-tools:${opensearch_version}"
         classpath 'org.ajoberstar:gradle-git:0.2.3'
     }
 }

--- a/build.gradle
+++ b/build.gradle
@@ -66,6 +66,12 @@ ext {
     rcaProjectDir = findProperty("rcaProjectDir") ?: "../performance-analyzer-rca"
 }
 
+group = "org.opensearch"
+version = "${performanceAnalyzerVersion}.0-beta1"
+if (isSnapshot) {
+    version += "-SNAPSHOT"
+}
+
 spotbugsMain {
     excludeFilter = file("checkstyle/findbugs-exclude.xml")
     effort = 'max'
@@ -79,12 +85,6 @@ spotbugsMain {
 
 spotbugsTest {
     ignoreFailures = true
-}
-
-group = "org.opensearch"
-version = "${performanceAnalyzer}.0-beta1"
-if (isSnapshot) {
-    version += "-SNAPSHOT"
 }
 
 apply plugin: 'opensearch.opensearchplugin'


### PR DESCRIPTION
- Removes the buildRca task as a default build dependency
- Simplifies the build.gradle file structure
- Updates and simplifies the github build workflow
- Run workflow when pushing to any branch

**Is your feature request related to a problem? Please provide an existing Issue # , or describe.**
- Our workflow checks out and builds performance-analyzer-rca more than once: as part of the GitHub action and as part of the gradle build. 
- The build.gradle and GitHub action files are long and somewhat difficult to read.

**Describe the solution you are proposing**
- I've added two new project properties to the gradle build fild: `cloneRcaProject` and `rcaProjectDir`. If `cloneRcaProject is true, then gradle will checkout RCA during the build to the location specified by `rcaProjectDir`. Otherwise, the build will assume that RCA has already been checked out to that location (and will fail if that assumption is false).
- Various readability improvements to build.gradle and the GitHub action file.

**Describe alternatives you've considered**
- We could completely remove support for checking out RCA as part of the PA build and provide developer instructions to do it outside of the build. However, because out build file creates artifacts that can be used for testing with docker this functionality remains useful.
- We could remove steps from the GitHub action to checkout and build RCA, and rely on the gradle build exclusively. I think it's nice to have the steps there explicitly because it acts as a sort of documentation for our build process.

**Additional context**
Add any other context or screenshots about the feature request here.

### Check List
- [ ] New functionality includes testing.
  - [x] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [ ] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/performance-analyzer/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
