### PR TITLE
Update plugin name and add release notes

### DIFF
--- a/release-notes/opendistro-for-elasticsearch-performance-analyzer.release-notes-1.13.0.0.md
+++ b/release-notes/opendistro-for-elasticsearch-performance-analyzer.release-notes-1.13.0.0.md
@@ -1,4 +1,4 @@
-## 2021-02-02 Version 1.13.0.0 (Current)
+## 2021-02-02 Version 1.13.0.0
 
 Supported Elasticsearch version 7.10.2
 

--- a/release-notes/opensearch-performance-analyzer.release-notes-1.0.0.0-beta1.md
+++ b/release-notes/opensearch-performance-analyzer.release-notes-1.0.0.0-beta1.md
@@ -1,0 +1,19 @@
+## 2021-04-26 Version 1.0.0.0-beta1 Release Notes
+
+Compatible with OpenSearch 1.0.0-alpha1
+
+### Infrastructure
+
+* OpenSearch fork changes ([#1](https://github.com/opensearch-project/performance-analyzer/pull/1))
+* OpenSearch fork changes ([#3](https://github.com/opensearch-project/performance-analyzer-rca/pull/3))
+* Modify opensearch version and fix buiild CI ([#4](https://github.com/opensearch-project/performance-analyzer/pull/4))
+* Add missing metricsdb* files and enable spotless ([#5](https://github.com/opensearch-project/performance-analyzer-rca/pull/5))
+* Update version to 1.x ([#6](https://github.com/opensearch-project/performance-analyzer/pull/6))
+* Update version to 1.0 beta ([#6](https://github.com/opensearch-project/performance-analyzer-rca/pull/6))
+* Update plugin name and add release notes ([#7](https://github.com/opensearch-project/performance-analyzer/pull/7))
+* Fix Integration test and update README ([#7](https://github.com/opensearch-project/performance-analyzer-rca/pull/7))
+
+### Documentation
+
+* Add SPDX license identifier ([#3](https://github.com/opensearch-project/performance-analyzer/pull/3))
+* Add SPDX license identifier ([#4](https://github.com/opensearch-project/performance-analyzer-rca/pull/4))

--- a/src/main/java/com/amazon/opendistro/opensearch/performanceanalyzer/PerformanceAnalyzerPlugin.java
+++ b/src/main/java/com/amazon/opendistro/opensearch/performanceanalyzer/PerformanceAnalyzerPlugin.java
@@ -126,7 +126,7 @@ import org.opensearch.watcher.ResourceWatcherService;
 public final class PerformanceAnalyzerPlugin extends Plugin
         implements ActionPlugin, NetworkPlugin, SearchPlugin {
     private static final Logger LOG = LogManager.getLogger(PerformanceAnalyzerPlugin.class);
-    public static final String PLUGIN_NAME = "opendistro-performance-analyzer";
+    public static final String PLUGIN_NAME = "opensearch-performance-analyzer";
     private static final String ADD_FAULT_DETECTION_METHOD = "addFaultDetectionListener";
     private static final String LISTENER_INJECTOR_CLASS_PATH =
             "com.amazon.opendistro.opensearch.performanceanalyzer.listener.ListenerInjector";


### PR DESCRIPTION
Signed-off-by: Sruti Parthiban <partsrut@amazon.com>

**Is your feature request related to a problem? Please provide an existing Issue # , or describe.**
Update plugin name and add release notes for beta release.

**Describe the solution you are proposing**
A clear and concise description of what you want to happen.

**Describe alternatives you've considered**
A clear and concise description of any alternative solutions or features you've considered.

**Additional context**
Integration testing passing in local. 

```
> Task :integTest

com.amazon.opendistro.opensearch.performanceanalyzer.integ_test.HeapMetricsIT > checkHeapInit STANDARD_OUT
    [2021-04-26T23:01:45,414][INFO ][c.a.o.o.p.i.HeapMetricsIT] [checkHeapInit] before test
    [2021-04-26T23:01:45,698][INFO ][c.a.o.o.p.i.HeapMetricsIT] [checkHeapInit] initializing REST clients against [http://localhost:9200]
    [2021-04-26T23:01:46,690][INFO ][c.a.o.o.p.i.HeapMetricsIT] [checkHeapInit] Cluster is localhost:9200
    [2021-04-26T23:01:46,691][INFO ][c.a.o.o.p.i.HeapMetricsIT] [checkHeapInit] initializing PerformanceAnalyzer client against [http://localhost:9600]
    [2021-04-26T23:01:48,475][INFO ][c.a.o.o.p.i.HeapMetricsIT] [checkHeapInit] Heap_Init value is 512.0
    [2021-04-26T23:01:52,078][INFO ][c.a.o.o.p.i.HeapMetricsIT] [checkHeapInit] Heap_Init value is 512.0
    [2021-04-26T23:01:52,078][INFO ][c.a.o.o.p.i.HeapMetricsIT] [checkHeapInit] Heap_Init value is 512.0
    [2021-04-26T23:01:52,137][INFO ][c.a.o.o.p.i.HeapMetricsIT] [checkHeapInit] after test

com.amazon.opendistro.opensearch.performanceanalyzer.integ_test.HeapMetricsIT > checkHeapUsed STANDARD_OUT
    [2021-04-26T23:01:52,207][INFO ][c.a.o.o.p.i.HeapMetricsIT] [checkHeapUsed] before test
    [2021-04-26T23:01:52,210][INFO ][c.a.o.o.p.i.HeapMetricsIT] [checkHeapUsed] initializing REST clients against [http://localhost:9200]
    [2021-04-26T23:01:52,353][INFO ][c.a.o.o.p.i.HeapMetricsIT] [checkHeapUsed] Cluster is localhost:9200
    [2021-04-26T23:01:52,354][INFO ][c.a.o.o.p.i.HeapMetricsIT] [checkHeapUsed] initializing PerformanceAnalyzer client against [http://localhost:9600]
    [2021-04-26T23:01:52,472][INFO ][c.a.o.o.p.i.HeapMetricsIT] [checkHeapUsed] Heap_Used value is 143.66978454589844
    [2021-04-26T23:01:52,588][INFO ][c.a.o.o.p.i.HeapMetricsIT] [checkHeapUsed] Heap_Used value is 135.09487915039062
    [2021-04-26T23:01:52,588][INFO ][c.a.o.o.p.i.HeapMetricsIT] [checkHeapUsed] Heap_Used value is 143.66978454589844
    [2021-04-26T23:01:52,592][INFO ][c.a.o.o.p.i.HeapMetricsIT] [checkHeapUsed] after test

com.amazon.opendistro.opensearch.performanceanalyzer.integ_test.HeapMetricsIT > checkHeapMax STANDARD_OUT
    [2021-04-26T23:01:52,601][INFO ][c.a.o.o.p.i.HeapMetricsIT] [checkHeapMax] before test
    [2021-04-26T23:01:52,602][INFO ][c.a.o.o.p.i.HeapMetricsIT] [checkHeapMax] initializing REST clients against [http://localhost:9200]
    [2021-04-26T23:01:52,662][INFO ][c.a.o.o.p.i.HeapMetricsIT] [checkHeapMax] Cluster is localhost:9200
    [2021-04-26T23:01:52,663][INFO ][c.a.o.o.p.i.HeapMetricsIT] [checkHeapMax] initializing PerformanceAnalyzer client against [http://localhost:9600]
    [2021-04-26T23:01:52,750][INFO ][c.a.o.o.p.i.HeapMetricsIT] [checkHeapMax] Heap_Max value is 495.375
    [2021-04-26T23:01:52,864][INFO ][c.a.o.o.p.i.HeapMetricsIT] [checkHeapMax] Heap_Max value is 495.375
    [2021-04-26T23:01:52,864][INFO ][c.a.o.o.p.i.HeapMetricsIT] [checkHeapMax] Heap_Max value is 495.375
    [2021-04-26T23:01:52,866][INFO ][c.a.o.o.p.i.HeapMetricsIT] [checkHeapMax] after test

com.amazon.opendistro.opensearch.performanceanalyzer.integ_test.CpuMetricsIT > checkCPUUtilization STANDARD_OUT
    [2021-04-26T15:01:53,036][INFO ][c.a.o.o.p.i.CpuMetricsIT ] [checkCPUUtilization] before test
    [2021-04-26T15:01:53,039][INFO ][c.a.o.o.p.i.CpuMetricsIT ] [checkCPUUtilization] initializing REST clients against [http://localhost:9200]
    [2021-04-26T15:01:53,114][INFO ][c.a.o.o.p.i.CpuMetricsIT ] [checkCPUUtilization] Cluster is localhost:9200
    [2021-04-26T15:01:53,115][INFO ][c.a.o.o.p.i.CpuMetricsIT ] [checkCPUUtilization] initializing PerformanceAnalyzer client against [http://localhost:9600]
    [2021-04-26T15:01:53,652][INFO ][c.a.o.o.p.i.CpuMetricsIT ] [checkCPUUtilization] after test

com.amazon.opendistro.opensearch.performanceanalyzer.integ_test.PageFaultMetricsIT > checkPaging_MajfltRate STANDARD_OUT
    [2021-04-26T22:01:53,738][INFO ][c.a.o.o.p.i.PageFaultMetricsIT] [checkPaging_MajfltRate] before test
    [2021-04-26T22:01:53,745][INFO ][c.a.o.o.p.i.PageFaultMetricsIT] [checkPaging_MajfltRate] initializing REST clients against [http://localhost:9200]
    [2021-04-26T22:01:53,820][INFO ][c.a.o.o.p.i.PageFaultMetricsIT] [checkPaging_MajfltRate] Cluster is localhost:9200
    [2021-04-26T22:01:53,820][INFO ][c.a.o.o.p.i.PageFaultMetricsIT] [checkPaging_MajfltRate] initializing PerformanceAnalyzer client against [http://localhost:9600]
    [2021-04-26T22:01:53,995][INFO ][c.a.o.o.p.i.PageFaultMetricsIT] [checkPaging_MajfltRate] after test

com.amazon.opendistro.opensearch.performanceanalyzer.integ_test.PageFaultMetricsIT > checkPaging_RSS STANDARD_OUT
    [2021-04-26T22:01:54,004][INFO ][c.a.o.o.p.i.PageFaultMetricsIT] [checkPaging_RSS] before test
    [2021-04-26T22:01:54,005][INFO ][c.a.o.o.p.i.PageFaultMetricsIT] [checkPaging_RSS] initializing REST clients against [http://localhost:9200]
    [2021-04-26T22:01:54,049][INFO ][c.a.o.o.p.i.PageFaultMetricsIT] [checkPaging_RSS] Cluster is localhost:9200
    [2021-04-26T22:01:54,049][INFO ][c.a.o.o.p.i.PageFaultMetricsIT] [checkPaging_RSS] initializing PerformanceAnalyzer client against [http://localhost:9600]
    [2021-04-26T22:01:54,188][INFO ][c.a.o.o.p.i.PageFaultMetricsIT] [checkPaging_RSS] after test

com.amazon.opendistro.opensearch.performanceanalyzer.integ_test.PageFaultMetricsIT > checkPaging_MinfltRate STANDARD_OUT
    [2021-04-26T22:01:54,197][INFO ][c.a.o.o.p.i.PageFaultMetricsIT] [checkPaging_MinfltRate] before test
    [2021-04-26T22:01:54,198][INFO ][c.a.o.o.p.i.PageFaultMetricsIT] [checkPaging_MinfltRate] initializing REST clients against [http://localhost:9200]
    [2021-04-26T22:01:54,223][INFO ][c.a.o.o.p.i.PageFaultMetricsIT] [checkPaging_MinfltRate] Cluster is localhost:9200
    [2021-04-26T22:01:54,223][INFO ][c.a.o.o.p.i.PageFaultMetricsIT] [checkPaging_MinfltRate] initializing PerformanceAnalyzer client against [http://localhost:9600]
    [2021-04-26T22:01:54,333][INFO ][c.a.o.o.p.i.PageFaultMetricsIT] [checkPaging_MinfltRate] after test

com.amazon.opendistro.opensearch.performanceanalyzer.ConfigOverridesIT > testCompositeOverrides STANDARD_OUT
    [2021-04-26T16:01:54,400][INFO ][c.a.o.o.p.ConfigOverridesIT] [testCompositeOverrides] before test
    [2021-04-26T16:01:54,403][INFO ][c.a.o.o.p.ConfigOverridesIT] [testCompositeOverrides] initializing REST clients against [http://localhost:9200]
    [2021-04-26T16:01:54,452][INFO ][c.a.o.o.p.ConfigOverridesIT] [testCompositeOverrides] Cluster is localhost:9200
    [2021-04-26T16:01:54,452][INFO ][c.a.o.o.p.ConfigOverridesIT] [testCompositeOverrides] initializing PerformanceAnalyzer client against [http://localhost:9600]
    [2021-04-26T16:01:55,737][INFO ][c.a.o.o.p.ConfigOverridesIT] [testCompositeOverrides] after test

com.amazon.opendistro.opensearch.performanceanalyzer.ConfigOverridesIT > testSimpleOverride STANDARD_OUT
    [2021-04-26T16:01:55,744][INFO ][c.a.o.o.p.ConfigOverridesIT] [testSimpleOverride] before test
    [2021-04-26T16:01:55,745][INFO ][c.a.o.o.p.ConfigOverridesIT] [testSimpleOverride] initializing REST clients against [http://localhost:9200]
    [2021-04-26T16:01:55,780][INFO ][c.a.o.o.p.ConfigOverridesIT] [testSimpleOverride] Cluster is localhost:9200
    [2021-04-26T16:01:55,780][INFO ][c.a.o.o.p.ConfigOverridesIT] [testSimpleOverride] initializing PerformanceAnalyzer client against [http://localhost:9600]
    [2021-04-26T16:01:56,215][INFO ][c.a.o.o.p.ConfigOverridesIT] [testSimpleOverride] after test

com.amazon.opendistro.opensearch.performanceanalyzer.PerformanceAnalyzerRCAHealthCheckIT > checkMetrics STANDARD_OUT
    [2021-04-26T16:01:56,286][INFO ][c.a.o.o.p.PerformanceAnalyzerRCAHealthCheckIT] [checkMetrics] before test
    [2021-04-26T16:01:56,290][INFO ][c.a.o.o.p.PerformanceAnalyzerRCAHealthCheckIT] [checkMetrics] initializing REST clients against [http://localhost:9200]
    [2021-04-26T16:01:56,339][INFO ][c.a.o.o.p.PerformanceAnalyzerRCAHealthCheckIT] [checkMetrics] Cluster is localhost:9200
    [2021-04-26T16:01:56,339][INFO ][c.a.o.o.p.PerformanceAnalyzerRCAHealthCheckIT] [checkMetrics] initializing PerformanceAnalyzer client against [http://localhost:9600]
    [2021-04-26T16:01:56,423][INFO ][c.a.o.o.p.PerformanceAnalyzerRCAHealthCheckIT] [checkMetrics] jsonString is {"1AFdUyHWTrqJAhZ-UKrFTQ": {"timestamp": 1619467290000, "data": {"fields":[{"name":"Disk_Utilization","type":"DOUBLE"}],"records":[[0.03557312252964427]]}}, "pKamjXd4Qwy7hXYra-_kyA" :{"timestamp": 1619467290000, "data": {"fields":[{"name":"Disk_Utilization","type":"DOUBLE"}],"records":[[0.03677058353317346]]}}}
    [2021-04-26T16:01:56,427][INFO ][c.a.o.o.p.PerformanceAnalyzerRCAHealthCheckIT] [checkMetrics] after test

com.amazon.opendistro.opensearch.performanceanalyzer.PerformanceAnalyzerRCAHealthCheckIT > testRcaIsRunning STANDARD_OUT
    [2021-04-26T16:01:56,433][INFO ][c.a.o.o.p.PerformanceAnalyzerRCAHealthCheckIT] [testRcaIsRunning] before test
    [2021-04-26T16:01:56,433][INFO ][c.a.o.o.p.PerformanceAnalyzerRCAHealthCheckIT] [testRcaIsRunning] initializing REST clients against [http://localhost:9200]
    [2021-04-26T16:01:56,468][INFO ][c.a.o.o.p.PerformanceAnalyzerRCAHealthCheckIT] [testRcaIsRunning] Cluster is localhost:9200
    [2021-04-26T16:01:56,468][INFO ][c.a.o.o.p.PerformanceAnalyzerRCAHealthCheckIT] [testRcaIsRunning] initializing PerformanceAnalyzer client against [http://localhost:9600]
    [2021-04-26T16:02:20,011][INFO ][c.a.o.o.p.PerformanceAnalyzerRCAHealthCheckIT] [testRcaIsRunning] after test

Gradle Test Executor 1 finished executing tests.

> Task :integTest
Finished generating test XML results (0.025 secs) into: /Users/partsrut/Desktop/workspace/os/performance-analyzer/build/test-results/integTest
Generating HTML test report...
Finished generating test html results (0.04 secs) into: /Users/partsrut/Desktop/workspace/os/performance-analyzer/build/reports/tests/integTest
Stored cache entry for task ':integTest' with cache key 6e7c17f6209e9a6f7313bd340d7007ad
Stopping `node{::integTest-0}`, tailLogs: false
Terminating opensearch process forcibly : commandLine:`/Library/Java/JavaVirtualMachines/jdk-14.0.1.jdk/Contents/Home/bin/java -Xshare:auto -Dopensearch.networkaddress.cache.ttl=60 -Dopensearch.networkaddress.cache.negative.ttl=10 -XX:+AlwaysPreTouch -Xss1m -Djava.awt.headless=true -Dfile.encoding=UTF-8 -Djna.nosys=true -XX:-OmitStackTraceInFastThrow -XX:+ShowCodeDetailsInExceptionMessages -Dio.netty.noUnsafe=true -Dio.netty.noKeySetOptimization=true -Dio.netty.recycler.maxCapacityPerThread=0 -Dio.netty.allocator.numDirectArenas=0 -Dlog4j.shutdownHookEnabled=false -Dlog4j2.disable.jmx=true -Djava.locale.providers=SPI,COMPAT -Xms1g -Xmx1g -XX:+UseG1GC -XX:G1ReservePercent=25 -XX:InitiatingHeapOccupancyPercent=30 -Djava.io.tmpdir=/Users/partsrut/Desktop/workspace/os/performance-analyzer/build/testclusters/integTest-0/tmp -XX:+HeapDumpOnOutOfMemoryError -XX:HeapDumpPath=logs -XX:ErrorFile=logs/hs_err_pid%p.log -Xlog:gc*,gc+age=trace,safepoint:file=logs/gc.log:utctime,pid,tags:filecount=32,filesize=64m -Xms512m -Xmx512m -ea -esa -XX:MaxDirectMemorySize=268435456 -Dopensearch.path.home=/Users/partsrut/.gradle/caches/transforms-2/files-2.1/740aa4486c484e0fef23288dd6b18215/opensearch-1.0.0-alpha1.zip/opensearch-1.0.0-alpha1 -Dopensearch.path.conf=/Users/partsrut/Desktop/workspace/os/performance-analyzer/build/testclusters/integTest-0/config -Dopensearch.distribution.type=zip -Dopensearch.bundled_jdk=false -cp /Users/partsrut/.gradle/caches/transforms-2/files-2.1/740aa4486c484e0fef23288dd6b18215/opensearch-1.0.0-alpha1.zip/opensearch-1.0.0-alpha1/lib/* org.opensearch.bootstrap.OpenSearch` command:`/Library/Java/JavaVirtualMachines/jdk-14.0.1.jdk/Contents/Home/bin/java` args:`'-Xshare:auto' '-Dopensearch.networkaddress.cache.ttl=60' '-Dopensearch.networkaddress.cache.negative.ttl=10' '-XX:+AlwaysPreTouch' '-Xss1m' '-Djava.awt.headless=true' '-Dfile.encoding=UTF-8' '-Djna.nosys=true' '-XX:-OmitStackTraceInFastThrow' '-XX:+ShowCodeDetailsInExceptionMessages' '-Dio.netty.noUnsafe=true' '-Dio.netty.noKeySetOptimization=true' '-Dio.netty.recycler.maxCapacityPerThread=0' '-Dio.netty.allocator.numDirectArenas=0' '-Dlog4j.shutdownHookEnabled=false' '-Dlog4j2.disable.jmx=true' '-Djava.locale.providers=SPI,COMPAT' '-Xms1g' '-Xmx1g' '-XX:+UseG1GC' '-XX:G1ReservePercent=25' '-XX:InitiatingHeapOccupancyPercent=30' '-Djava.io.tmpdir=/Users/partsrut/Desktop/workspace/os/performance-analyzer/build/testclusters/integTest-0/tmp' '-XX:+HeapDumpOnOutOfMemoryError' '-XX:HeapDumpPath=logs' '-XX:ErrorFile=logs/hs_err_pid%p.log' '-Xlog:gc*,gc+age=trace,safepoint:file=logs/gc.log:utctime,pid,tags:filecount=32,filesize=64m' '-Xms512m' '-Xmx512m' '-ea' '-esa' '-XX:MaxDirectMemorySize=268435456' '-Dopensearch.path.home=/Users/partsrut/.gradle/caches/transforms-2/files-2.1/740aa4486c484e0fef23288dd6b18215/opensearch-1.0.0-alpha1.zip/opensearch-1.0.0-alpha1' '-Dopensearch.path.conf=/Users/partsrut/Desktop/workspace/os/performance-analyzer/build/testclusters/integTest-0/config' '-Dopensearch.distribution.type=zip' '-Dopensearch.bundled_jdk=false' '-cp' '/Users/partsrut/.gradle/caches/transforms-2/files-2.1/740aa4486c484e0fef23288dd6b18215/opensearch-1.0.0-alpha1.zip/opensearch-1.0.0-alpha1/lib/*' 'org.opensearch.bootstrap.OpenSearch'`
:integTest (Thread[Daemon worker Thread 2,5,main]) completed. Took 48.585 secs.
Waiting for reaper to exit normally

Deprecated Gradle features were used in this build, making it incompatible with Gradle 7.0.
Use '--warning-mode all' to show the individual deprecation warnings.
See https://docs.gradle.org/6.6.1/userguide/command_line_interface.html#sec:command_line_warnings

BUILD SUCCESSFUL in 3m 57s
```

### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [ ] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/performance-analyzer/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
