### PR TITLE
Create conf directory if not exist to avoid NoSuchFile exceptions

### DIFF
--- a/src/main/java/com/amazon/opendistro/opensearch/performanceanalyzer/config/PerformanceAnalyzerController.java
+++ b/src/main/java/com/amazon/opendistro/opensearch/performanceanalyzer/config/PerformanceAnalyzerController.java
@@ -290,6 +290,7 @@ public class PerformanceAnalyzerController {
                     try {
                         Path destDir = Paths.get(getDataDirectory());
                         if (!Files.exists(destDir)) {
+                            StatsCollector.instance().logException(StatExceptionCode.CONFIG_DIR_NOT_FOUND);
                             Files.createDirectory(destDir);
                         }
                         Files.write(

--- a/src/main/java/com/amazon/opendistro/opensearch/performanceanalyzer/config/PerformanceAnalyzerController.java
+++ b/src/main/java/com/amazon/opendistro/opensearch/performanceanalyzer/config/PerformanceAnalyzerController.java
@@ -30,6 +30,8 @@ package com.amazon.opendistro.opensearch.performanceanalyzer.config;
 import com.amazon.opendistro.opensearch.performanceanalyzer.OpenSearchResources;
 import com.amazon.opendistro.opensearch.performanceanalyzer.PerformanceAnalyzerPlugin;
 import com.amazon.opendistro.opensearch.performanceanalyzer.collectors.ScheduledMetricCollectorsExecutor;
+import com.amazon.opendistro.opensearch.performanceanalyzer.collectors.StatExceptionCode;
+import com.amazon.opendistro.opensearch.performanceanalyzer.collectors.StatsCollector;
 import com.amazon.opendistro.opensearch.performanceanalyzer.config.overrides.ConfigOverridesWrapper;
 import com.amazon.opendistro.opensearch.performanceanalyzer.metrics.PerformanceAnalyzerMetrics;
 import java.io.File;
@@ -290,7 +292,8 @@ public class PerformanceAnalyzerController {
                     try {
                         Path destDir = Paths.get(getDataDirectory());
                         if (!Files.exists(destDir)) {
-                            StatsCollector.instance().logException(StatExceptionCode.CONFIG_DIR_NOT_FOUND);
+                            StatsCollector.instance()
+                                    .logException(StatExceptionCode.CONFIG_DIR_NOT_FOUND);
                             Files.createDirectory(destDir);
                         }
                         Files.write(

--- a/src/main/java/com/amazon/opendistro/opensearch/performanceanalyzer/config/PerformanceAnalyzerController.java
+++ b/src/main/java/com/amazon/opendistro/opensearch/performanceanalyzer/config/PerformanceAnalyzerController.java
@@ -288,6 +288,10 @@ public class PerformanceAnalyzerController {
         PerformanceAnalyzerPlugin.invokePrivileged(
                 () -> {
                     try {
+                        Path destDir = Paths.get(getDataDirectory());
+                        if (!Files.exists(destDir)) {
+                            Files.createDirectory(destDir);
+                        }
                         Files.write(
                                 Paths.get(getDataDirectory() + File.separator + fileName),
                                 String.valueOf(featureEnabled).getBytes());


### PR DESCRIPTION
Signoff by: Harold Xiao haoruxia@amazon.com

**Describe the solution you are proposing**
When running PA unit tests, errors with NoSuchFile exceptions will pop out, the reason is that the path to store the conf files is not exist. This PR add a conditional check to add the directory to avoid the exceptions. 

**Describe alternatives you've considered**
A clear and concise description of any alternative solutions or features you've considered.

**Additional context**
Add any other context or screenshots about the feature request here.
Prerequisite: Add CONFIG_DIR_NOT_FOUND in StatExceptionCode 
(https://github.com/opensearch-project/performance-analyzer-rca/pull/11/files)

### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [x] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/performance-analyzer/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
