### PR TITLE
Upgrade Jackson version to 2.11.4

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -222,6 +222,8 @@ dependencies {
         compile files("${System.properties['java.home']}/../lib/tools.jar")
     }
 
+    def jacksonVersion = "2.11.4"
+
     configurations {
         // jarHell reports class name conflicts between securemock and mockito-core
         // has to disable one of them.
@@ -232,11 +234,6 @@ dependencies {
 
     configurations.all {
        resolutionStrategy {
-          force 'com.fasterxml.jackson.core:jackson-databind:2.10.5.1'
-          force 'com.fasterxml.jackson.core:jackson-core:2.10.5'
-          force 'com.fasterxml.jackson.dataformat:jackson-dataformat-smile:2.10.5'
-          force 'com.fasterxml.jackson.dataformat:jackson-dataformat-yaml:2.10.5'
-          force 'com.fasterxml.jackson.dataformat:jackson-dataformat-cbor:2.10.5'
           force 'junit:junit:4.13.1'
        }
     }
@@ -249,9 +246,9 @@ dependencies {
     compile 'org.bouncycastle:bcprov-jdk15on:1.68'
     compile 'org.bouncycastle:bcpkix-jdk15on:1.68'
     compile 'com.amazon.opensearch:performanceanalyzer-rca:1.0.0.0-beta1'
-    compile 'com.fasterxml.jackson.core:jackson-annotations:2.10.5'
-    compile 'com.fasterxml.jackson.core:jackson-databind:2.10.5.1'
-    compile 'com.fasterxml.jackson.module:jackson-module-paranamer:2.10.5'
+    compile "com.fasterxml.jackson.core:jackson-annotations:${jacksonVersion}"
+    compile "com.fasterxml.jackson.core:jackson-databind:${jacksonVersion}"
+    compile "com.fasterxml.jackson.module:jackson-module-paranamer:${jacksonVersion}"
     compile(group: 'org.apache.logging.log4j', name: 'log4j-api', version: '2.11.1') {
         force = 'true'
     }

--- a/build.gradle
+++ b/build.gradle
@@ -235,6 +235,9 @@ dependencies {
     configurations.all {
        resolutionStrategy {
           force 'junit:junit:4.13.1'
+          force "com.fasterxml.jackson.core:jackson-annotations:${jacksonVersion}"
+          force "com.fasterxml.jackson.core:jackson-databind:${jacksonVersion}"
+          force "com.fasterxml.jackson.module:jackson-module-paranamer:${jacksonVersion}"
        }
     }
 

--- a/build.gradle
+++ b/build.gradle
@@ -236,6 +236,7 @@ dependencies {
        resolutionStrategy {
           force 'junit:junit:4.13.1'
           force "com.fasterxml.jackson.core:jackson-annotations:${jacksonVersion}"
+          force "com.fasterxml.jackson.core:jackson-core:${jacksonVersion}"
           force "com.fasterxml.jackson.core:jackson-databind:${jacksonVersion}"
           force "com.fasterxml.jackson.module:jackson-module-paranamer:${jacksonVersion}"
        }


### PR DESCRIPTION
Upgrade Jackson version to 2.11.4 to match OpenSearch core.

https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2020-28491

**Is your feature request related to a problem? Please provide an existing Issue # , or describe.**
The older version of Jackson was flagged in the linked CVE.

**Describe the solution you are proposing**
Upgrade to a later version not affect by the CVE. The version 2.11.4 is chosen to match OpenSearch core.

**Describe alternatives you've considered**
We could upgrade to a later version of Jackson, but I think it makes sense to match OpenSearch core to avoid any compatibility bugs. Note that the CVE does not apply to versions 2.11.4 and later.

### Check List
- [x] New functionality includes testing.
  - [x] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [ ] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/performance-analyzer/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
