### PR TITLE
Update REST resources to follow new OpenSearch naming convention

### DIFF
--- a/src/main/java/org/opensearch/performanceanalyzer/http_action/config/PerformanceAnalyzerClusterConfigAction.java
+++ b/src/main/java/org/opensearch/performanceanalyzer/http_action/config/PerformanceAnalyzerClusterConfigAction.java
@@ -30,6 +30,7 @@ import static java.util.Arrays.asList;
 import static java.util.Collections.unmodifiableList;
 
 import java.io.IOException;
+import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import org.apache.logging.log4j.LogManager;
@@ -59,28 +60,69 @@ public class PerformanceAnalyzerClusterConfigAction extends BaseRestHandler {
     public static final String CURRENT = "currentPerformanceAnalyzerClusterState";
     public static final String BATCH_METRICS_RETENTION_PERIOD_MINUTES =
             "batchMetricsRetentionPeriodMinutes";
-    public static final String PA_CLUSTER_CONFIG_PATH =
-            "/_opendistro/_performanceanalyzer/cluster/config";
-    public static final String RCA_CLUSTER_CONFIG_PATH =
-            "/_opendistro/_performanceanalyzer/rca/cluster/config";
-    public static final String LOGGING_CLUSTER_CONFIG_PATH =
-            "/_opendistro/_performanceanalyzer/logging/cluster/config";
-    public static final String BATCH_METRICS_CLUSTER_CONFIG_PATH =
-            "/_opendistro/_performanceanalyzer/batch/cluster/config";
     public static final String ENABLED = "enabled";
     public static final String SHARDS_PER_COLLECTION = "shardsPerCollection";
 
-    private static final List<Route> ROUTES =
+    public static final String PA_CLUSTER_CONFIG_PATH = RestConfig.PA_BASE_URI + "/cluster/config";
+    public static final String RCA_CLUSTER_CONFIG_PATH =
+            RestConfig.PA_BASE_URI + "/rca/cluster/config";
+    public static final String LOGGING_CLUSTER_CONFIG_PATH =
+            RestConfig.PA_BASE_URI + "/logging/cluster/config";
+    public static final String BATCH_METRICS_CLUSTER_CONFIG_PATH =
+            RestConfig.PA_BASE_URI + "/batch/cluster/config";
+
+    public static final String LEGACY_PA_CLUSTER_CONFIG_PATH =
+            RestConfig.LEGACY_PA_BASE_URI + "/cluster/config";
+    public static final String LEGACY_RCA_CLUSTER_CONFIG_PATH =
+            RestConfig.LEGACY_PA_BASE_URI + "/rca/cluster/config";
+    public static final String LEGACY_LOGGING_CLUSTER_CONFIG_PATH =
+            RestConfig.LEGACY_PA_BASE_URI + "/logging/cluster/config";
+    public static final String LEGACY_BATCH_METRICS_CLUSTER_CONFIG_PATH =
+            RestConfig.LEGACY_PA_BASE_URI + "/batch/cluster/config";
+
+    private static final List<ReplacedRoute> REPLACED_ROUTES =
             unmodifiableList(
                     asList(
-                            new Route(RestRequest.Method.GET, PA_CLUSTER_CONFIG_PATH),
-                            new Route(RestRequest.Method.POST, PA_CLUSTER_CONFIG_PATH),
-                            new Route(RestRequest.Method.GET, RCA_CLUSTER_CONFIG_PATH),
-                            new Route(RestRequest.Method.POST, RCA_CLUSTER_CONFIG_PATH),
-                            new Route(RestRequest.Method.GET, LOGGING_CLUSTER_CONFIG_PATH),
-                            new Route(RestRequest.Method.POST, LOGGING_CLUSTER_CONFIG_PATH),
-                            new Route(RestRequest.Method.GET, BATCH_METRICS_CLUSTER_CONFIG_PATH),
-                            new Route(RestRequest.Method.POST, BATCH_METRICS_CLUSTER_CONFIG_PATH)));
+                            new ReplacedRoute(
+                                    RestRequest.Method.GET,
+                                    PA_CLUSTER_CONFIG_PATH,
+                                    RestRequest.Method.GET,
+                                    LEGACY_PA_CLUSTER_CONFIG_PATH),
+                            new ReplacedRoute(
+                                    RestRequest.Method.POST,
+                                    PA_CLUSTER_CONFIG_PATH,
+                                    RestRequest.Method.POST,
+                                    LEGACY_PA_CLUSTER_CONFIG_PATH),
+                            new ReplacedRoute(
+                                    RestRequest.Method.GET,
+                                    RCA_CLUSTER_CONFIG_PATH,
+                                    RestRequest.Method.GET,
+                                    LEGACY_RCA_CLUSTER_CONFIG_PATH),
+                            new ReplacedRoute(
+                                    RestRequest.Method.POST,
+                                    RCA_CLUSTER_CONFIG_PATH,
+                                    RestRequest.Method.POST,
+                                    LEGACY_RCA_CLUSTER_CONFIG_PATH),
+                            new ReplacedRoute(
+                                    RestRequest.Method.GET,
+                                    LOGGING_CLUSTER_CONFIG_PATH,
+                                    RestRequest.Method.GET,
+                                    LEGACY_LOGGING_CLUSTER_CONFIG_PATH),
+                            new ReplacedRoute(
+                                    RestRequest.Method.POST,
+                                    LOGGING_CLUSTER_CONFIG_PATH,
+                                    RestRequest.Method.POST,
+                                    LEGACY_LOGGING_CLUSTER_CONFIG_PATH),
+                            new ReplacedRoute(
+                                    RestRequest.Method.GET,
+                                    BATCH_METRICS_CLUSTER_CONFIG_PATH,
+                                    RestRequest.Method.GET,
+                                    LEGACY_BATCH_METRICS_CLUSTER_CONFIG_PATH),
+                            new ReplacedRoute(
+                                    RestRequest.Method.POST,
+                                    BATCH_METRICS_CLUSTER_CONFIG_PATH,
+                                    RestRequest.Method.POST,
+                                    LEGACY_BATCH_METRICS_CLUSTER_CONFIG_PATH)));
 
     private final PerformanceAnalyzerClusterSettingHandler clusterSettingHandler;
     private final NodeStatsSettingHandler nodeStatsSettingHandler;
@@ -105,7 +147,12 @@ public class PerformanceAnalyzerClusterConfigAction extends BaseRestHandler {
 
     @Override
     public List<Route> routes() {
-        return ROUTES;
+        return Collections.emptyList();
+    }
+
+    @Override
+    public List<ReplacedRoute> replacedRoutes() {
+        return REPLACED_ROUTES;
     }
 
     /**

--- a/src/main/java/org/opensearch/performanceanalyzer/http_action/config/PerformanceAnalyzerConfigAction.java
+++ b/src/main/java/org/opensearch/performanceanalyzer/http_action/config/PerformanceAnalyzerConfigAction.java
@@ -30,6 +30,7 @@ import static java.util.Arrays.asList;
 import static java.util.Collections.unmodifiableList;
 
 import java.io.IOException;
+import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import org.apache.logging.log4j.LogManager;
@@ -63,24 +64,63 @@ public class PerformanceAnalyzerConfigAction extends BaseRestHandler {
             "batchMetricsRetentionPeriodMinutes";
     public static final String PERFORMANCE_ANALYZER_CONFIG_ACTION =
             "PerformanceAnalyzer_Config_Action";
-    public static final String RCA_CONFIG_PATH = "/_opendistro/_performanceanalyzer/rca/config";
-    public static final String PA_CONFIG_PATH = "/_opendistro/_performanceanalyzer/config";
-    public static final String LOGGING_CONFIG_PATH =
-            "/_opendistro/_performanceanalyzer/logging/config";
-    public static final String BATCH_METRICS_CONFIG_PATH =
-            "/_opendistro/_performanceanalyzer/batch/config";
 
-    private static final List<Route> ROUTES =
+    public static final String RCA_CONFIG_PATH = RestConfig.PA_BASE_URI + "/rca/config";
+    public static final String PA_CONFIG_PATH = RestConfig.PA_BASE_URI + "/config";
+    public static final String LOGGING_CONFIG_PATH = RestConfig.PA_BASE_URI + "/logging/config";
+    public static final String BATCH_METRICS_CONFIG_PATH = RestConfig.PA_BASE_URI + "/batch/config";
+
+    public static final String LEGACY_RCA_CONFIG_PATH =
+            RestConfig.LEGACY_PA_BASE_URI + "/rca/config";
+    public static final String LEGACY_PA_CONFIG_PATH = RestConfig.LEGACY_PA_BASE_URI + "/config";
+    public static final String LEGACY_LOGGING_CONFIG_PATH =
+            RestConfig.LEGACY_PA_BASE_URI + "/logging/config";
+    public static final String LEGACY_BATCH_METRICS_CONFIG_PATH =
+            RestConfig.LEGACY_PA_BASE_URI + "/batch/config";
+
+    private static final List<ReplacedRoute> REPLACED_ROUTES =
             unmodifiableList(
                     asList(
-                            new Route(RestRequest.Method.GET, PA_CONFIG_PATH),
-                            new Route(RestRequest.Method.POST, PA_CONFIG_PATH),
-                            new Route(RestRequest.Method.GET, RCA_CONFIG_PATH),
-                            new Route(RestRequest.Method.POST, RCA_CONFIG_PATH),
-                            new Route(RestRequest.Method.GET, LOGGING_CONFIG_PATH),
-                            new Route(RestRequest.Method.POST, LOGGING_CONFIG_PATH),
-                            new Route(RestRequest.Method.GET, BATCH_METRICS_CONFIG_PATH),
-                            new Route(RestRequest.Method.POST, BATCH_METRICS_CONFIG_PATH)));
+                            new ReplacedRoute(
+                                    RestRequest.Method.GET,
+                                    PA_CONFIG_PATH,
+                                    RestRequest.Method.GET,
+                                    LEGACY_PA_CONFIG_PATH),
+                            new ReplacedRoute(
+                                    RestRequest.Method.POST,
+                                    PA_CONFIG_PATH,
+                                    RestRequest.Method.POST,
+                                    LEGACY_PA_CONFIG_PATH),
+                            new ReplacedRoute(
+                                    RestRequest.Method.GET,
+                                    RCA_CONFIG_PATH,
+                                    RestRequest.Method.GET,
+                                    LEGACY_RCA_CONFIG_PATH),
+                            new ReplacedRoute(
+                                    RestRequest.Method.POST,
+                                    RCA_CONFIG_PATH,
+                                    RestRequest.Method.POST,
+                                    LEGACY_RCA_CONFIG_PATH),
+                            new ReplacedRoute(
+                                    RestRequest.Method.GET,
+                                    LOGGING_CONFIG_PATH,
+                                    RestRequest.Method.GET,
+                                    LEGACY_LOGGING_CONFIG_PATH),
+                            new ReplacedRoute(
+                                    RestRequest.Method.POST,
+                                    LOGGING_CONFIG_PATH,
+                                    RestRequest.Method.POST,
+                                    LEGACY_LOGGING_CONFIG_PATH),
+                            new ReplacedRoute(
+                                    RestRequest.Method.GET,
+                                    BATCH_METRICS_CONFIG_PATH,
+                                    RestRequest.Method.GET,
+                                    LEGACY_BATCH_METRICS_CONFIG_PATH),
+                            new ReplacedRoute(
+                                    RestRequest.Method.POST,
+                                    BATCH_METRICS_CONFIG_PATH,
+                                    RestRequest.Method.POST,
+                                    LEGACY_BATCH_METRICS_CONFIG_PATH)));
 
     public static PerformanceAnalyzerConfigAction getInstance() {
         return instance;
@@ -93,7 +133,12 @@ public class PerformanceAnalyzerConfigAction extends BaseRestHandler {
 
     @Override
     public List<Route> routes() {
-        return ROUTES;
+        return Collections.emptyList();
+    }
+
+    @Override
+    public List<ReplacedRoute> replacedRoutes() {
+        return REPLACED_ROUTES;
     }
 
     @Inject
@@ -119,7 +164,8 @@ public class PerformanceAnalyzerConfigAction extends BaseRestHandler {
                     performanceAnalyzerController.isPerformanceAnalyzerEnabled());
             if (value instanceof Boolean) {
                 boolean shouldEnable = (Boolean) value;
-                if (request.path().contains(RCA_CONFIG_PATH)) {
+                if (request.path().contains(RCA_CONFIG_PATH)
+                        || request.path().contains(LEGACY_RCA_CONFIG_PATH)) {
                     // If RCA needs to be turned on, we need to have PA turned on also.
                     // If this is not the case, return error.
                     if (shouldEnable
@@ -129,7 +175,8 @@ public class PerformanceAnalyzerConfigAction extends BaseRestHandler {
                     }
 
                     performanceAnalyzerController.updateRcaState(shouldEnable);
-                } else if (request.path().contains(LOGGING_CONFIG_PATH)) {
+                } else if (request.path().contains(LOGGING_CONFIG_PATH)
+                        || request.path().contains(LEGACY_LOGGING_CONFIG_PATH)) {
                     if (shouldEnable
                             && !performanceAnalyzerController.isPerformanceAnalyzerEnabled()) {
                         return getChannelConsumerWithError(
@@ -137,7 +184,8 @@ public class PerformanceAnalyzerConfigAction extends BaseRestHandler {
                     }
 
                     performanceAnalyzerController.updateLoggingState(shouldEnable);
-                } else if (request.path().contains(BATCH_METRICS_CONFIG_PATH)) {
+                } else if (request.path().contains(BATCH_METRICS_CONFIG_PATH)
+                        || request.path().contains(LEGACY_BATCH_METRICS_CONFIG_PATH)) {
                     if (shouldEnable
                             && !performanceAnalyzerController.isPerformanceAnalyzerEnabled()) {
                         return getChannelConsumerWithError(

--- a/src/main/java/org/opensearch/performanceanalyzer/http_action/config/PerformanceAnalyzerOverridesClusterConfigAction.java
+++ b/src/main/java/org/opensearch/performanceanalyzer/http_action/config/PerformanceAnalyzerOverridesClusterConfigAction.java
@@ -55,16 +55,26 @@ public class PerformanceAnalyzerOverridesClusterConfigAction extends BaseRestHan
     private static final Logger LOG =
             LogManager.getLogger(PerformanceAnalyzerOverridesClusterConfigAction.class);
     public static final String PA_CONFIG_OVERRIDES_PATH =
-            "/_opendistro/_performanceanalyzer/override/cluster/config";
+            RestConfig.PA_BASE_URI + "/override/cluster/config";
+    public static final String LEGACY_PA_CONFIG_OVERRIDES_PATH =
+            RestConfig.LEGACY_PA_BASE_URI + "/override/cluster/config";
     private static final String OVERRIDES_FIELD = "overrides";
     private static final String REASON_FIELD = "reason";
     public static final String OVERRIDE_TRIGGERED_FIELD = "override triggered";
 
-    private static final List<Route> ROUTES =
+    private static final List<ReplacedRoute> REPLACED_ROUTES =
             unmodifiableList(
                     asList(
-                            new Route(RestRequest.Method.GET, PA_CONFIG_OVERRIDES_PATH),
-                            new Route(RestRequest.Method.POST, PA_CONFIG_OVERRIDES_PATH)));
+                            new ReplacedRoute(
+                                    RestRequest.Method.GET,
+                                    PA_CONFIG_OVERRIDES_PATH,
+                                    RestRequest.Method.GET,
+                                    LEGACY_PA_CONFIG_OVERRIDES_PATH),
+                            new ReplacedRoute(
+                                    RestRequest.Method.POST,
+                                    PA_CONFIG_OVERRIDES_PATH,
+                                    RestRequest.Method.POST,
+                                    LEGACY_PA_CONFIG_OVERRIDES_PATH)));
 
     private final ConfigOverridesClusterSettingHandler configOverridesClusterSettingHandler;
     private final ConfigOverridesWrapper overridesWrapper;
@@ -81,7 +91,12 @@ public class PerformanceAnalyzerOverridesClusterConfigAction extends BaseRestHan
 
     @Override
     public List<Route> routes() {
-        return ROUTES;
+        return Collections.emptyList();
+    }
+
+    @Override
+    public List<ReplacedRoute> replacedRoutes() {
+        return REPLACED_ROUTES;
     }
 
     /** @return the name of this handler. */

--- a/src/main/java/org/opensearch/performanceanalyzer/http_action/config/RestConfig.java
+++ b/src/main/java/org/opensearch/performanceanalyzer/http_action/config/RestConfig.java
@@ -1,0 +1,33 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ *
+ * Modifications Copyright OpenSearch Contributors. See
+ * GitHub history for details.
+ */
+
+/*
+ * Copyright 2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package org.opensearch.performanceanalyzer.http_action.config;
+
+/** Shared constants and configuration used by the REST controllers defined by this plugin. */
+public class RestConfig {
+    public static final String PA_BASE_URI = "/_plugins/_performanceanalyzer";
+    public static final String LEGACY_PA_BASE_URI = "/_opendistro/_performanceanalyzer";
+}

--- a/src/test/java/org/opensearch/performanceanalyzer/ConfigOverridesIT.java
+++ b/src/test/java/org/opensearch/performanceanalyzer/ConfigOverridesIT.java
@@ -42,11 +42,12 @@ import org.junit.Test;
 import org.opensearch.client.Request;
 import org.opensearch.client.Response;
 import org.opensearch.performanceanalyzer.config.overrides.ConfigOverrides;
+import org.opensearch.performanceanalyzer.http_action.config.RestConfig;
 import org.opensearch.performanceanalyzer.util.WaitFor;
 
 public class ConfigOverridesIT extends PerformanceAnalyzerIntegTestBase {
     private static final String CONFIG_OVERRIDES_ENDPOINT =
-            PERFORMANCE_ANALYZER_BASE_ENDPOINT + "/override/cluster/config";
+            RestConfig.PA_BASE_URI + "/override/cluster/config";
 
     private static final List<String> EMPTY_LIST = Collections.emptyList();
     public static final String HOT_SHARD_RCA = "HotShardRca";

--- a/src/test/java/org/opensearch/performanceanalyzer/PerformanceAnalyzerIntegTestBase.java
+++ b/src/test/java/org/opensearch/performanceanalyzer/PerformanceAnalyzerIntegTestBase.java
@@ -63,13 +63,12 @@ import org.opensearch.common.unit.TimeValue;
 import org.opensearch.common.util.concurrent.ThreadContext;
 import org.opensearch.performanceanalyzer.config.setting.PerformanceAnalyzerClusterSettings;
 import org.opensearch.performanceanalyzer.config.setting.handler.PerformanceAnalyzerClusterSettingHandler;
+import org.opensearch.performanceanalyzer.http_action.config.RestConfig;
 import org.opensearch.performanceanalyzer.util.WaitFor;
 import org.opensearch.test.rest.OpenSearchRestTestCase;
 
 public abstract class PerformanceAnalyzerIntegTestBase extends OpenSearchRestTestCase {
     private static final Logger LOG = LogManager.getLogger(PerformanceAnalyzerIntegTestBase.class);
-    protected static final String PERFORMANCE_ANALYZER_BASE_ENDPOINT =
-            "/_opendistro/_performanceanalyzer";
     private int paPort;
     protected static final ObjectMapper mapper = new ObjectMapper();
     // TODO this must be initialized at construction time to avoid NPEs, we should find a way for
@@ -223,10 +222,10 @@ public abstract class PerformanceAnalyzerIntegTestBase extends OpenSearchRestTes
         String endpoint;
         switch (component) {
             case PA:
-                endpoint = PERFORMANCE_ANALYZER_BASE_ENDPOINT + "/cluster/config";
+                endpoint = RestConfig.PA_BASE_URI + "/cluster/config";
                 break;
             case RCA:
-                endpoint = PERFORMANCE_ANALYZER_BASE_ENDPOINT + "/rca/cluster/config";
+                endpoint = RestConfig.PA_BASE_URI + "/rca/cluster/config";
                 break;
             default:
                 throw new IllegalArgumentException(
@@ -261,9 +260,7 @@ public abstract class PerformanceAnalyzerIntegTestBase extends OpenSearchRestTes
         // Sanity check that PA and RCA are enabled on the cluster
         Response resp =
                 client().performRequest(
-                                new Request(
-                                        "GET",
-                                        PERFORMANCE_ANALYZER_BASE_ENDPOINT + "/cluster/config"));
+                                new Request("GET", RestConfig.PA_BASE_URI + "/cluster/config"));
         Map<String, Object> respMap =
                 mapper.readValue(
                         EntityUtils.toString(resp.getEntity(), "UTF-8"),

--- a/src/test/java/org/opensearch/performanceanalyzer/PerformanceAnalyzerRCAHealthCheckIT.java
+++ b/src/test/java/org/opensearch/performanceanalyzer/PerformanceAnalyzerRCAHealthCheckIT.java
@@ -37,6 +37,7 @@ import org.junit.Assert;
 import org.junit.Test;
 import org.opensearch.client.Request;
 import org.opensearch.client.Response;
+import org.opensearch.performanceanalyzer.http_action.config.RestConfig;
 import org.opensearch.performanceanalyzer.util.WaitFor;
 
 public class PerformanceAnalyzerRCAHealthCheckIT extends PerformanceAnalyzerIntegTestBase {
@@ -49,7 +50,8 @@ public class PerformanceAnalyzerRCAHealthCheckIT extends PerformanceAnalyzerInte
                     Request request =
                             new Request(
                                     "GET",
-                                    "/_opendistro/_performanceanalyzer/metrics/?metrics=Disk_Utilization&agg=max&dim=&nodes=all");
+                                    RestConfig.PA_BASE_URI
+                                            + "/metrics/?metrics=Disk_Utilization&agg=max&dim=&nodes=all");
                     Response resp = paClient.performRequest(request);
                     Assert.assertEquals(HttpStatus.SC_OK, resp.getStatusLine().getStatusCode());
                     jsonString[0] = EntityUtils.toString(resp.getEntity());
@@ -87,7 +89,7 @@ public class PerformanceAnalyzerRCAHealthCheckIT extends PerformanceAnalyzerInte
         ensurePaAndRcaEnabled();
         WaitFor.waitFor(
                 () -> {
-                    Request request = new Request("GET", "/_opendistro/_performanceanalyzer/rca");
+                    Request request = new Request("GET", RestConfig.PA_BASE_URI + "/rca");
                     try {
                         Response resp = paClient.performRequest(request);
                         return Objects.equals(

--- a/src/test/java/org/opensearch/performanceanalyzer/http_action/config/PerformanceAnalyzerClusterConfigActionTests.java
+++ b/src/test/java/org/opensearch/performanceanalyzer/http_action/config/PerformanceAnalyzerClusterConfigActionTests.java
@@ -33,7 +33,6 @@ import static org.mockito.MockitoAnnotations.initMocks;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Collections;
-import java.util.List;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
@@ -54,7 +53,6 @@ import org.opensearch.performanceanalyzer.config.setting.ClusterSettingsManager;
 import org.opensearch.performanceanalyzer.config.setting.handler.NodeStatsSettingHandler;
 import org.opensearch.performanceanalyzer.config.setting.handler.PerformanceAnalyzerClusterSettingHandler;
 import org.opensearch.rest.RestController;
-import org.opensearch.rest.RestHandler.Route;
 import org.opensearch.rest.RestRequest;
 import org.opensearch.rest.RestStatus;
 import org.opensearch.test.rest.FakeRestChannel;
@@ -114,8 +112,7 @@ public class PerformanceAnalyzerClusterConfigActionTests {
 
     @Test
     public void testRoutes() {
-        List<Route> routes = configAction.routes();
-        assertEquals(8, routes.size());
+        assertEquals(8, configAction.replacedRoutes().size());
     }
 
     @Test
@@ -131,8 +128,19 @@ public class PerformanceAnalyzerClusterConfigActionTests {
     }
 
     @Test
+    public void testLegacyUpdateRcaSetting() throws IOException {
+        testWithRequestPath(PerformanceAnalyzerClusterConfigAction.LEGACY_RCA_CLUSTER_CONFIG_PATH);
+    }
+
+    @Test
     public void testUpdateLoggingSetting() throws IOException {
         testWithRequestPath(PerformanceAnalyzerClusterConfigAction.LOGGING_CLUSTER_CONFIG_PATH);
+    }
+
+    @Test
+    public void testLegacyUpdateLoggingSetting() throws IOException {
+        testWithRequestPath(
+                PerformanceAnalyzerClusterConfigAction.LEGACY_LOGGING_CLUSTER_CONFIG_PATH);
     }
 
     @Test
@@ -142,8 +150,19 @@ public class PerformanceAnalyzerClusterConfigActionTests {
     }
 
     @Test
+    public void testLegacyUpdateBatchMetricsSetting() throws IOException {
+        testWithRequestPath(
+                PerformanceAnalyzerClusterConfigAction.LEGACY_BATCH_METRICS_CLUSTER_CONFIG_PATH);
+    }
+
+    @Test
     public void testUpdatePerformanceAnalyzerSetting() throws IOException {
         testWithRequestPath(PerformanceAnalyzerClusterConfigAction.PA_CLUSTER_CONFIG_PATH);
+    }
+
+    @Test
+    public void testLegacyUpdatePerformanceAnalyzerSetting() throws IOException {
+        testWithRequestPath(PerformanceAnalyzerClusterConfigAction.LEGACY_PA_CLUSTER_CONFIG_PATH);
     }
 
     private void testWithRequestPath(String requestPath) throws IOException {

--- a/src/test/java/org/opensearch/performanceanalyzer/http_action/config/PerformanceAnalyzerConfigActionTests.java
+++ b/src/test/java/org/opensearch/performanceanalyzer/http_action/config/PerformanceAnalyzerConfigActionTests.java
@@ -33,7 +33,6 @@ import static org.mockito.MockitoAnnotations.initMocks;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Collections;
-import java.util.List;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
@@ -52,7 +51,6 @@ import org.opensearch.indices.breaker.CircuitBreakerService;
 import org.opensearch.indices.breaker.HierarchyCircuitBreakerService;
 import org.opensearch.performanceanalyzer.config.PerformanceAnalyzerController;
 import org.opensearch.rest.RestController;
-import org.opensearch.rest.RestHandler.Route;
 import org.opensearch.rest.RestRequest;
 import org.opensearch.rest.RestStatus;
 import org.opensearch.test.rest.FakeRestChannel;
@@ -104,8 +102,7 @@ public class PerformanceAnalyzerConfigActionTests {
 
     @Test
     public void testRoutes() {
-        List<Route> routes = configAction.routes();
-        assertEquals(8, routes.size());
+        assertEquals(8, configAction.replacedRoutes().size());
     }
 
     @Test
@@ -121,8 +118,18 @@ public class PerformanceAnalyzerConfigActionTests {
     }
 
     @Test
+    public void testLegacyUpdateRcaState_ShouldEnable_paEnabled() throws IOException {
+        test(PerformanceAnalyzerConfigAction.LEGACY_RCA_CONFIG_PATH, true, true);
+    }
+
+    @Test
     public void testUpdateRcaState_ShouldEnable_paDisabled() throws IOException {
         test(PerformanceAnalyzerConfigAction.RCA_CONFIG_PATH, true, false);
+    }
+
+    @Test
+    public void testLegacyUpdateRcaState_ShouldEnable_paDisabled() throws IOException {
+        test(PerformanceAnalyzerConfigAction.LEGACY_RCA_CONFIG_PATH, true, false);
     }
 
     @Test
@@ -131,8 +138,18 @@ public class PerformanceAnalyzerConfigActionTests {
     }
 
     @Test
+    public void testLegacyUpdateRcaState_ShouldDisable_paEnabled() throws IOException {
+        test(PerformanceAnalyzerConfigAction.LEGACY_RCA_CONFIG_PATH, false, true);
+    }
+
+    @Test
     public void testUpdateRcaState_ShouldDisable_paDisabled() throws IOException {
         test(PerformanceAnalyzerConfigAction.RCA_CONFIG_PATH, false, false);
+    }
+
+    @Test
+    public void testLegacyUpdateRcaState_ShouldDisable_paDisabled() throws IOException {
+        test(PerformanceAnalyzerConfigAction.LEGACY_RCA_CONFIG_PATH, false, false);
     }
 
     @Test
@@ -141,8 +158,18 @@ public class PerformanceAnalyzerConfigActionTests {
     }
 
     @Test
+    public void testLegacyUpdateLoggingState_ShouldEnable_paEnabled() throws IOException {
+        test(PerformanceAnalyzerConfigAction.LEGACY_LOGGING_CONFIG_PATH, true, true);
+    }
+
+    @Test
     public void testUpdateLoggingState_ShouldEnable_paDisabled() throws IOException {
         test(PerformanceAnalyzerConfigAction.LOGGING_CONFIG_PATH, true, false);
+    }
+
+    @Test
+    public void testLegacyUpdateLoggingState_ShouldEnable_paDisabled() throws IOException {
+        test(PerformanceAnalyzerConfigAction.LEGACY_LOGGING_CONFIG_PATH, true, false);
     }
 
     @Test
@@ -151,8 +178,18 @@ public class PerformanceAnalyzerConfigActionTests {
     }
 
     @Test
+    public void testLegacyUpdateLoggingState_ShouldDisable_paEnabled() throws IOException {
+        test(PerformanceAnalyzerConfigAction.LEGACY_LOGGING_CONFIG_PATH, false, true);
+    }
+
+    @Test
     public void testUpdateLoggingState_ShouldDisable_paDisabled() throws IOException {
         test(PerformanceAnalyzerConfigAction.LOGGING_CONFIG_PATH, false, false);
+    }
+
+    @Test
+    public void testLegacyUpdateLoggingState_ShouldDisable_paDisabled() throws IOException {
+        test(PerformanceAnalyzerConfigAction.LEGACY_LOGGING_CONFIG_PATH, false, false);
     }
 
     @Test
@@ -161,8 +198,18 @@ public class PerformanceAnalyzerConfigActionTests {
     }
 
     @Test
+    public void testLegacyUpdateBatchMetricsState_ShouldEnable_paEnabled() throws IOException {
+        test(PerformanceAnalyzerConfigAction.LEGACY_BATCH_METRICS_CONFIG_PATH, true, true);
+    }
+
+    @Test
     public void testUpdateBatchMetricsState_ShouldEnable_paDisabled() throws IOException {
         test(PerformanceAnalyzerConfigAction.BATCH_METRICS_CONFIG_PATH, true, false);
+    }
+
+    @Test
+    public void testLegacyUpdateBatchMetricsState_ShouldEnable_paDisabled() throws IOException {
+        test(PerformanceAnalyzerConfigAction.LEGACY_BATCH_METRICS_CONFIG_PATH, true, false);
     }
 
     @Test
@@ -171,8 +218,18 @@ public class PerformanceAnalyzerConfigActionTests {
     }
 
     @Test
+    public void testLegacyUpdateBatchMetricsState_ShouldDisable_paEnabled() throws IOException {
+        test(PerformanceAnalyzerConfigAction.LEGACY_BATCH_METRICS_CONFIG_PATH, false, true);
+    }
+
+    @Test
     public void testUpdateBatchMetricsState_ShouldDisable_paDisabled() throws IOException {
         test(PerformanceAnalyzerConfigAction.BATCH_METRICS_CONFIG_PATH, false, false);
+    }
+
+    @Test
+    public void testLegacyUpdateBatchMetricsState_ShouldDisable_paDisabled() throws IOException {
+        test(PerformanceAnalyzerConfigAction.LEGACY_BATCH_METRICS_CONFIG_PATH, false, false);
     }
 
     @Test
@@ -181,13 +238,31 @@ public class PerformanceAnalyzerConfigActionTests {
     }
 
     @Test
+    public void testLegacyUpdatePerformanceAnalyzerState_ShouldEnable_paEnabled()
+            throws IOException {
+        test(PerformanceAnalyzerConfigAction.LEGACY_PA_CONFIG_PATH, true, true);
+    }
+
+    @Test
     public void testUpdatePerformanceAnalyzerState_ShouldDisable_paEnabled() throws IOException {
         test(PerformanceAnalyzerConfigAction.PA_CONFIG_PATH, false, true);
     }
 
     @Test
+    public void testLegacyUpdatePerformanceAnalyzerState_ShouldDisable_paEnabled()
+            throws IOException {
+        test(PerformanceAnalyzerConfigAction.LEGACY_PA_CONFIG_PATH, false, true);
+    }
+
+    @Test
     public void testUpdatePerformanceAnalyzerState_ShouldDisable_paDisabled() throws IOException {
         test(PerformanceAnalyzerConfigAction.PA_CONFIG_PATH, false, false);
+    }
+
+    @Test
+    public void testLegacyUpdatePerformanceAnalyzerState_ShouldDisable_paDisabled()
+            throws IOException {
+        test(PerformanceAnalyzerConfigAction.LEGACY_PA_CONFIG_PATH, false, false);
     }
 
     private void test(String requestPath, boolean shouldEnable, boolean paEnabled)

--- a/src/test/java/org/opensearch/performanceanalyzer/http_action/config/PerformanceAnalyzerResourceProviderTests.java
+++ b/src/test/java/org/opensearch/performanceanalyzer/http_action/config/PerformanceAnalyzerResourceProviderTests.java
@@ -102,17 +102,21 @@ public class PerformanceAnalyzerResourceProviderTests {
         return request;
     }
 
-    private void assertAgentUriWithMetricsRedirection(final String protocolScheme)
-            throws IOException {
+    private void assertAgentUriWithMetricsRedirection(
+            final String protocolScheme, String requestBasePath) throws IOException {
         initPerformanceAnalyzerResourceProvider(protocolScheme.equals("https://"));
 
         String requestURI =
                 protocolScheme
-                        + "localhost:9200/_opendistro/_performanceanalyzer/_agent/metrics"
+                        + "localhost:9200"
+                        + requestBasePath
+                        + "/_agent/metrics"
                         + "?metrics=Latency,CPU_Utilization&agg=avg,max&dim=ShardID&nodes=all";
         String expectedResponseURI =
                 protocolScheme
-                        + "localhost:9600/_opendistro/_performanceanalyzer/metrics"
+                        + "localhost:9600"
+                        + RestConfig.PA_BASE_URI
+                        + "/metrics"
                         + "?metrics=Latency,CPU_Utilization&agg=avg,max&dim=ShardID&nodes=all";
 
         RestRequest restRequest = generateRestRequest(requestURI, "metrics");
@@ -120,16 +124,21 @@ public class PerformanceAnalyzerResourceProviderTests {
         assertEquals(new URL(expectedResponseURI), actualResponseURI);
     }
 
-    private void assertAgentUriWithRcaRedirection(final String protocolScheme) throws IOException {
+    private void assertAgentUriWithRcaRedirection(
+            final String protocolScheme, String requestBasePath) throws IOException {
         initPerformanceAnalyzerResourceProvider(protocolScheme.equals("https://"));
 
         String requestUri =
                 protocolScheme
-                        + "localhost:9200/_opendistro/_performanceanalyzer/_agent/rca"
+                        + "localhost:9200"
+                        + requestBasePath
+                        + "/_agent/rca"
                         + "?rca=highShardCPU&startTime=2019-10-11";
         String expectedResponseUri =
                 protocolScheme
-                        + "localhost:9600/_opendistro/_performanceanalyzer/rca"
+                        + "localhost:9600"
+                        + RestConfig.PA_BASE_URI
+                        + "/rca"
                         + "?rca=highShardCPU&startTime=2019-10-11";
 
         RestRequest restRequest = generateRestRequest(requestUri, "rca");
@@ -137,17 +146,21 @@ public class PerformanceAnalyzerResourceProviderTests {
         assertEquals(new URL(expectedResponseUri), actualResponseURI);
     }
 
-    private void assertAgentUriWithBatchRedirection(final String protocolScheme)
-            throws IOException {
+    private void assertAgentUriWithBatchRedirection(
+            final String protocolScheme, String requestBasePath) throws IOException {
         initPerformanceAnalyzerResourceProvider(protocolScheme.equals("https://"));
 
         String requestUri =
                 protocolScheme
-                        + "localhost:9200/_opendistro/_performanceanalyzer/_agent/batch"
+                        + "localhost:9200"
+                        + requestBasePath
+                        + "/_agent/batch"
                         + "?metrics=CPU_Utilization,IO_TotThroughput&starttime=1594412650000&endtime=1594412665000&samplingperiod=5";
         String expectedResponseUri =
                 protocolScheme
-                        + "localhost:9600/_opendistro/_performanceanalyzer/batch"
+                        + "localhost:9600"
+                        + RestConfig.PA_BASE_URI
+                        + "/batch"
                         + "?metrics=CPU_Utilization,IO_TotThroughput&starttime=1594412650000&endtime=1594412665000&samplingperiod=5";
 
         RestRequest restRequest = generateRestRequest(requestUri, "batch");
@@ -155,14 +168,13 @@ public class PerformanceAnalyzerResourceProviderTests {
         assertEquals(new URL(expectedResponseUri), actualResponseURI);
     }
 
-    private void assertAgentUriWithActionsRedirection(final String protocolScheme)
-            throws IOException {
+    private void assertAgentUriWithActionsRedirection(
+            final String protocolScheme, String requestBasePath) throws IOException {
         initPerformanceAnalyzerResourceProvider(protocolScheme.equals("https://"));
 
-        String requestUri =
-                protocolScheme + "localhost:9200/_opendistro/_performanceanalyzer/_agent/actions";
+        String requestUri = protocolScheme + "localhost:9200" + requestBasePath + "/_agent/actions";
         String expectedResponseUri =
-                protocolScheme + "localhost:9600/_opendistro/_performanceanalyzer/actions";
+                protocolScheme + "localhost:9600" + RestConfig.PA_BASE_URI + "/actions";
 
         RestRequest restRequest = generateRestRequest(requestUri, "actions");
         URL actualResponseURI = performanceAnalyzerRp.getAgentUri(restRequest);
@@ -171,42 +183,50 @@ public class PerformanceAnalyzerResourceProviderTests {
 
     @Test
     public void testGetAgentUri_WithHttp_WithMetricRedirection() throws Exception {
-        assertAgentUriWithMetricsRedirection("http://");
+        assertAgentUriWithMetricsRedirection("http://", RestConfig.PA_BASE_URI);
+        assertAgentUriWithMetricsRedirection("http://", RestConfig.LEGACY_PA_BASE_URI);
     }
 
     @Test
     public void testGetAgentUri_WithHttps_WithMetricRedirection() throws Exception {
-        assertAgentUriWithRcaRedirection("https://");
+        assertAgentUriWithRcaRedirection("https://", RestConfig.PA_BASE_URI);
+        assertAgentUriWithRcaRedirection("https://", RestConfig.LEGACY_PA_BASE_URI);
     }
 
     @Test
     public void testGetAgentUri_WithHttp_WithRcaRedirection() throws Exception {
-        assertAgentUriWithRcaRedirection("http://");
+        assertAgentUriWithRcaRedirection("http://", RestConfig.PA_BASE_URI);
+        assertAgentUriWithRcaRedirection("http://", RestConfig.LEGACY_PA_BASE_URI);
     }
 
     @Test
     public void testGetAgentUri_WithHttps_WithRcaRedirection() throws Exception {
-        assertAgentUriWithRcaRedirection("https://");
+        assertAgentUriWithRcaRedirection("https://", RestConfig.PA_BASE_URI);
+        assertAgentUriWithRcaRedirection("https://", RestConfig.LEGACY_PA_BASE_URI);
     }
 
     @Test
     public void testGetAgentUri_WithHttp_WithBatchRedirection() throws Exception {
-        assertAgentUriWithBatchRedirection("http://");
+        assertAgentUriWithBatchRedirection("http://", RestConfig.PA_BASE_URI);
+        assertAgentUriWithBatchRedirection("http://", RestConfig.LEGACY_PA_BASE_URI);
     }
 
     @Test
     public void testGetAgentUri_WithHttps_WithBatchRedirection() throws Exception {
-        assertAgentUriWithBatchRedirection("https://");
+        assertAgentUriWithBatchRedirection("https://", RestConfig.PA_BASE_URI);
+        assertAgentUriWithBatchRedirection("https://", RestConfig.LEGACY_PA_BASE_URI);
     }
 
     @Test
     public void testGetAgentUri_WithHttp_WithActionsRedirection() throws Exception {
-        assertAgentUriWithActionsRedirection("http://");
+        assertAgentUriWithActionsRedirection("http://", RestConfig.PA_BASE_URI);
+        assertAgentUriWithActionsRedirection("http://", RestConfig.LEGACY_PA_BASE_URI);
     }
 
     @Test
     public void testGetAgentUri_WithHttps_WithActionsRedirection() throws Exception {
-        assertAgentUriWithActionsRedirection("https://");
+        assertAgentUriWithActionsRedirection("https://", RestConfig.PA_BASE_URI);
+        assertAgentUriWithActionsRedirection("https://", RestConfig.LEGACY_PA_BASE_URI);
     }
 
     @Test
@@ -214,6 +234,11 @@ public class PerformanceAnalyzerResourceProviderTests {
         String requestUri = "http://localhost:9200/_opendistro/_performanceanalyzer/_agent/invalid";
         RestRequest request = generateRestRequest(requestUri, "invalid");
         URL finalURI = performanceAnalyzerRp.getAgentUri(request);
+        assertNull(finalURI);
+
+        requestUri = "http://localhost:9200/_plugins/_performanceanalyzer/_agent/invalid";
+        request = generateRestRequest(requestUri, "invalid");
+        finalURI = performanceAnalyzerRp.getAgentUri(request);
         assertNull(finalURI);
     }
 }

--- a/src/test/java/org/opensearch/performanceanalyzer/integ_test/CpuMetricsIT.java
+++ b/src/test/java/org/opensearch/performanceanalyzer/integ_test/CpuMetricsIT.java
@@ -31,6 +31,7 @@ import java.util.List;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
+import org.opensearch.performanceanalyzer.http_action.config.RestConfig;
 import org.opensearch.performanceanalyzer.integ_test.json.JsonResponseData;
 import org.opensearch.performanceanalyzer.integ_test.json.JsonResponseField;
 import org.opensearch.performanceanalyzer.integ_test.json.JsonResponseNode;
@@ -47,16 +48,14 @@ public class CpuMetricsIT extends MetricCollectorIntegTestBase {
     public void checkCPUUtilization() throws Exception {
         // read metric from local node
         List<JsonResponseNode> responseNodeList =
-                readMetric(
-                        PERFORMANCE_ANALYZER_BASE_ENDPOINT
-                                + "/metrics/?metrics=CPU_Utilization&agg=sum");
+                readMetric(RestConfig.PA_BASE_URI + "/metrics/?metrics=CPU_Utilization&agg=sum");
         Assert.assertEquals(1, responseNodeList.size());
         validatePerNodeCPUMetric(responseNodeList.get(0));
 
         // read metric from all nodes in cluster
         responseNodeList =
                 readMetric(
-                        PERFORMANCE_ANALYZER_BASE_ENDPOINT
+                        RestConfig.PA_BASE_URI
                                 + "/metrics/?metrics=CPU_Utilization&agg=sum&nodes=all");
         int nodeNum = getNodeIDs().size();
         Assert.assertEquals(nodeNum, responseNodeList.size());

--- a/src/test/java/org/opensearch/performanceanalyzer/integ_test/HeapMetricsIT.java
+++ b/src/test/java/org/opensearch/performanceanalyzer/integ_test/HeapMetricsIT.java
@@ -34,6 +34,7 @@ import org.apache.logging.log4j.Logger;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
+import org.opensearch.performanceanalyzer.http_action.config.RestConfig;
 import org.opensearch.performanceanalyzer.integ_test.json.JsonResponseData;
 import org.opensearch.performanceanalyzer.integ_test.json.JsonResponseField;
 import org.opensearch.performanceanalyzer.integ_test.json.JsonResponseNode;
@@ -78,7 +79,7 @@ public class HeapMetricsIT extends MetricCollectorIntegTestBase {
         // read metric from local node
         List<JsonResponseNode> responseNodeList =
                 readMetric(
-                        PERFORMANCE_ANALYZER_BASE_ENDPOINT
+                        RestConfig.PA_BASE_URI
                                 + "/metrics/?metrics="
                                 + metric.toString()
                                 + "&agg=max");
@@ -88,7 +89,7 @@ public class HeapMetricsIT extends MetricCollectorIntegTestBase {
         // read metric from all nodes in cluster
         responseNodeList =
                 readMetric(
-                        PERFORMANCE_ANALYZER_BASE_ENDPOINT
+                        RestConfig.PA_BASE_URI
                                 + "/metrics/?metrics="
                                 + metric.toString()
                                 + "&agg=max&nodes=all");

--- a/src/test/java/org/opensearch/performanceanalyzer/integ_test/PageFaultMetricsIT.java
+++ b/src/test/java/org/opensearch/performanceanalyzer/integ_test/PageFaultMetricsIT.java
@@ -31,6 +31,7 @@ import java.util.List;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
+import org.opensearch.performanceanalyzer.http_action.config.RestConfig;
 import org.opensearch.performanceanalyzer.integ_test.json.JsonResponseData;
 import org.opensearch.performanceanalyzer.integ_test.json.JsonResponseField;
 import org.opensearch.performanceanalyzer.integ_test.json.JsonResponseNode;
@@ -47,16 +48,14 @@ public class PageFaultMetricsIT extends MetricCollectorIntegTestBase {
     public void checkPaging_MajfltRate() throws Exception {
         // read metric from local node
         List<JsonResponseNode> responseNodeList =
-                readMetric(
-                        PERFORMANCE_ANALYZER_BASE_ENDPOINT
-                                + "/metrics/?metrics=Paging_MajfltRate&agg=max");
+                readMetric(RestConfig.PA_BASE_URI + "/metrics/?metrics=Paging_MajfltRate&agg=max");
         Assert.assertEquals(1, responseNodeList.size());
         validateMajorPageFaultMetric(responseNodeList.get(0));
 
         // read metric from all nodes in cluster
         responseNodeList =
                 readMetric(
-                        PERFORMANCE_ANALYZER_BASE_ENDPOINT
+                        RestConfig.PA_BASE_URI
                                 + "/metrics/?metrics=Paging_MajfltRate&agg=max&nodes=all");
         int nodeNum = getNodeIDs().size();
         Assert.assertEquals(nodeNum, responseNodeList.size());
@@ -69,16 +68,14 @@ public class PageFaultMetricsIT extends MetricCollectorIntegTestBase {
     public void checkPaging_MinfltRate() throws Exception {
         // read metric from local node
         List<JsonResponseNode> responseNodeList =
-                readMetric(
-                        PERFORMANCE_ANALYZER_BASE_ENDPOINT
-                                + "/metrics/?metrics=Paging_MinfltRate&agg=max");
+                readMetric(RestConfig.PA_BASE_URI + "/metrics/?metrics=Paging_MinfltRate&agg=max");
         Assert.assertEquals(1, responseNodeList.size());
         validateMinorPageFaultMetric(responseNodeList.get(0));
 
         // read metric from all nodes in cluster
         responseNodeList =
                 readMetric(
-                        PERFORMANCE_ANALYZER_BASE_ENDPOINT
+                        RestConfig.PA_BASE_URI
                                 + "/metrics/?metrics=Paging_MinfltRate&agg=max&nodes=all");
         int nodeNum = getNodeIDs().size();
         Assert.assertEquals(nodeNum, responseNodeList.size());
@@ -91,17 +88,14 @@ public class PageFaultMetricsIT extends MetricCollectorIntegTestBase {
     public void checkPaging_RSS() throws Exception {
         // read metric from local node
         List<JsonResponseNode> responseNodeList =
-                readMetric(
-                        PERFORMANCE_ANALYZER_BASE_ENDPOINT
-                                + "/metrics/?metrics=Paging_RSS&agg=max");
+                readMetric(RestConfig.PA_BASE_URI + "/metrics/?metrics=Paging_RSS&agg=max");
         Assert.assertEquals(1, responseNodeList.size());
         validatePagingRSSMetric(responseNodeList.get(0));
 
         // read metric from all nodes in cluster
         responseNodeList =
                 readMetric(
-                        PERFORMANCE_ANALYZER_BASE_ENDPOINT
-                                + "/metrics/?metrics=Paging_RSS&agg=max&nodes=all");
+                        RestConfig.PA_BASE_URI + "/metrics/?metrics=Paging_RSS&agg=max&nodes=all");
         int nodeNum = getNodeIDs().size();
         Assert.assertEquals(nodeNum, responseNodeList.size());
         for (int i = 0; i < nodeNum; i++) {


### PR DESCRIPTION
Plugin resources will appear under `/_plugins` instead of `/_opendistro`.

**Describe the solution you are proposing**
Following the [upgrade guide](https://github.com/opensearch-project/opensearch-plugins/blob/main/UPGRADING.md#rest-apis-backward-compatibility) to rename our REST resources.

### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [ ] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/performance-analyzer/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
