### PR TITLE
Add legacy REST endpoints to integration tests

### DIFF
--- a/src/test/java/org/opensearch/performanceanalyzer/ConfigOverridesIT.java
+++ b/src/test/java/org/opensearch/performanceanalyzer/ConfigOverridesIT.java
@@ -110,7 +110,7 @@ public class ConfigOverridesIT extends PerformanceAnalyzerIntegTestBase {
     }
 
     @Test
-    public void testCompositeOverrides() throws Exception {
+    public void testLegacyCompositeOverrides() throws Exception {
         testCompositeOverrides(LEGACY_CONFIG_OVERRIDES_ENDPOINT);
     }
 

--- a/src/test/java/org/opensearch/performanceanalyzer/ConfigOverridesIT.java
+++ b/src/test/java/org/opensearch/performanceanalyzer/ConfigOverridesIT.java
@@ -49,7 +49,7 @@ public class ConfigOverridesIT extends PerformanceAnalyzerIntegTestBase {
     private static final String CONFIG_OVERRIDES_ENDPOINT =
             RestConfig.PA_BASE_URI + "/override/cluster/config";
 
-    private static final String LEGACY_CONFIG_OVERRIDES_ENDPOINT =
+    private static final String LEGACY_OPENDISTRO_CONFIG_OVERRIDES_ENDPOINT =
             RestConfig.LEGACY_PA_BASE_URI + "/override/cluster/config";
 
     private static final List<String> EMPTY_LIST = Collections.emptyList();
@@ -63,7 +63,7 @@ public class ConfigOverridesIT extends PerformanceAnalyzerIntegTestBase {
 
     @Test
     public void testLegacySimpleOverride() throws Exception {
-        testSimpleOverride(LEGACY_CONFIG_OVERRIDES_ENDPOINT);
+        testSimpleOverride(LEGACY_OPENDISTRO_CONFIG_OVERRIDES_ENDPOINT);
     }
 
     public void testSimpleOverride(String configOverridesEndpoint) throws Exception {
@@ -111,7 +111,7 @@ public class ConfigOverridesIT extends PerformanceAnalyzerIntegTestBase {
 
     @Test
     public void testLegacyCompositeOverrides() throws Exception {
-        testCompositeOverrides(LEGACY_CONFIG_OVERRIDES_ENDPOINT);
+        testCompositeOverrides(LEGACY_OPENDISTRO_CONFIG_OVERRIDES_ENDPOINT);
     }
 
     public void testCompositeOverrides(String configOverridesEndpoint) throws Exception {

--- a/src/test/java/org/opensearch/performanceanalyzer/ConfigOverridesIT.java
+++ b/src/test/java/org/opensearch/performanceanalyzer/ConfigOverridesIT.java
@@ -49,12 +49,24 @@ public class ConfigOverridesIT extends PerformanceAnalyzerIntegTestBase {
     private static final String CONFIG_OVERRIDES_ENDPOINT =
             RestConfig.PA_BASE_URI + "/override/cluster/config";
 
+    private static final String LEGACY_CONFIG_OVERRIDES_ENDPOINT =
+            RestConfig.LEGACY_PA_BASE_URI + "/override/cluster/config";
+
     private static final List<String> EMPTY_LIST = Collections.emptyList();
     public static final String HOT_SHARD_RCA = "HotShardRca";
     public static final String HOT_NODE_CLUSTER_RCA = "HotNodeClusterRca";
 
     @Test
     public void testSimpleOverride() throws Exception {
+        testSimpleOverride(CONFIG_OVERRIDES_ENDPOINT);
+    }
+
+    @Test
+    public void testLegacySimpleOverride() throws Exception {
+        testSimpleOverride(LEGACY_CONFIG_OVERRIDES_ENDPOINT);
+    }
+
+    public void testSimpleOverride(String configOverridesEndpoint) throws Exception {
         ensurePaAndRcaEnabled();
         final ConfigOverrides overrides =
                 getOverrides(
@@ -64,7 +76,7 @@ public class ConfigOverridesIT extends PerformanceAnalyzerIntegTestBase {
                         EMPTY_LIST,
                         EMPTY_LIST,
                         EMPTY_LIST);
-        final Request postRequest = new Request(METHOD_POST, CONFIG_OVERRIDES_ENDPOINT);
+        final Request postRequest = new Request(METHOD_POST, configOverridesEndpoint);
         postRequest.setJsonEntity(mapper.writeValueAsString(overrides));
 
         try {
@@ -78,7 +90,7 @@ public class ConfigOverridesIT extends PerformanceAnalyzerIntegTestBase {
         WaitFor.waitFor(
                 () -> {
                     try {
-                        Map<String, Object> responseEntity = getAsMap(CONFIG_OVERRIDES_ENDPOINT);
+                        Map<String, Object> responseEntity = getAsMap(configOverridesEndpoint);
                         String serializedOverrides = (String) responseEntity.get("overrides");
                         final ConfigOverrides computedOverrides =
                                 mapper.readValue(serializedOverrides, ConfigOverrides.class);
@@ -94,6 +106,15 @@ public class ConfigOverridesIT extends PerformanceAnalyzerIntegTestBase {
 
     @Test
     public void testCompositeOverrides() throws Exception {
+        testCompositeOverrides(CONFIG_OVERRIDES_ENDPOINT);
+    }
+
+    @Test
+    public void testCompositeOverrides() throws Exception {
+        testCompositeOverrides(LEGACY_CONFIG_OVERRIDES_ENDPOINT);
+    }
+
+    public void testCompositeOverrides(String configOverridesEndpoint) throws Exception {
         ensurePaAndRcaEnabled();
 
         final ConfigOverrides initialOverrides =
@@ -105,7 +126,7 @@ public class ConfigOverridesIT extends PerformanceAnalyzerIntegTestBase {
                         EMPTY_LIST,
                         EMPTY_LIST);
 
-        final Request postRequest = new Request(METHOD_POST, CONFIG_OVERRIDES_ENDPOINT);
+        final Request postRequest = new Request(METHOD_POST, configOverridesEndpoint);
         postRequest.setJsonEntity(mapper.writeValueAsString(initialOverrides));
 
         try {
@@ -118,7 +139,7 @@ public class ConfigOverridesIT extends PerformanceAnalyzerIntegTestBase {
 
         WaitFor.waitFor(
                 () -> {
-                    final Request getRequest = new Request(METHOD_GET, CONFIG_OVERRIDES_ENDPOINT);
+                    final Request getRequest = new Request(METHOD_GET, configOverridesEndpoint);
                     try {
                         final Response response = client().performRequest(getRequest);
                         assertEquals(HttpStatus.SC_OK, response.getStatusLine().getStatusCode());
@@ -148,7 +169,7 @@ public class ConfigOverridesIT extends PerformanceAnalyzerIntegTestBase {
                         EMPTY_LIST,
                         EMPTY_LIST);
 
-        final Request postRequestAdjusted = new Request(METHOD_POST, CONFIG_OVERRIDES_ENDPOINT);
+        final Request postRequestAdjusted = new Request(METHOD_POST, configOverridesEndpoint);
         postRequestAdjusted.setJsonEntity(mapper.writeValueAsString(adjustedOverrides));
 
         try {
@@ -170,7 +191,7 @@ public class ConfigOverridesIT extends PerformanceAnalyzerIntegTestBase {
 
         WaitFor.waitFor(
                 () -> {
-                    final Request getRequest = new Request(METHOD_GET, CONFIG_OVERRIDES_ENDPOINT);
+                    final Request getRequest = new Request(METHOD_GET, configOverridesEndpoint);
                     try {
                         final Response response = client().performRequest(getRequest);
                         assertEquals(HttpStatus.SC_OK, response.getStatusLine().getStatusCode());

--- a/src/test/java/org/opensearch/performanceanalyzer/PerformanceAnalyzerRCAHealthCheckIT.java
+++ b/src/test/java/org/opensearch/performanceanalyzer/PerformanceAnalyzerRCAHealthCheckIT.java
@@ -43,6 +43,15 @@ import org.opensearch.performanceanalyzer.util.WaitFor;
 public class PerformanceAnalyzerRCAHealthCheckIT extends PerformanceAnalyzerIntegTestBase {
     @Test
     public void checkMetrics() throws Exception {
+        checkMetrics(RestConfig.PA_BASE_URI);
+    }
+
+    @Test
+    public void checkLegacyMetrics() throws Exception {
+        checkMetrics(RestConfig.LEGACY_PA_BASE_URI);
+    }
+
+    public void checkMetrics(String paBaseUri) throws Exception {
         ensurePaAndRcaEnabled();
         final String[] jsonString = new String[1];
         WaitFor.waitFor(
@@ -50,7 +59,7 @@ public class PerformanceAnalyzerRCAHealthCheckIT extends PerformanceAnalyzerInte
                     Request request =
                             new Request(
                                     "GET",
-                                    RestConfig.PA_BASE_URI
+                                    paBaseUri
                                             + "/metrics/?metrics=Disk_Utilization&agg=max&dim=&nodes=all");
                     Response resp = paClient.performRequest(request);
                     Assert.assertEquals(HttpStatus.SC_OK, resp.getStatusLine().getStatusCode());
@@ -86,10 +95,19 @@ public class PerformanceAnalyzerRCAHealthCheckIT extends PerformanceAnalyzerInte
 
     @Test
     public void testRcaIsRunning() throws Exception {
+        testRcaIsRunning(RestConfig.PA_BASE_URI);
+    }
+
+    @Test
+    public void testLegacyRcaIsRunning() throws Exception {
+        testRcaIsRunning(RestConfig.LEGACY_PA_BASE_URI);
+    }
+
+    public void testRcaIsRunning(String paBaseUri) throws Exception {
         ensurePaAndRcaEnabled();
         WaitFor.waitFor(
                 () -> {
-                    Request request = new Request("GET", RestConfig.PA_BASE_URI + "/rca");
+                    Request request = new Request("GET", paBaseUri + "/rca");
                     try {
                         Response resp = paClient.performRequest(request);
                         return Objects.equals(

--- a/src/test/java/org/opensearch/performanceanalyzer/integ_test/CpuMetricsIT.java
+++ b/src/test/java/org/opensearch/performanceanalyzer/integ_test/CpuMetricsIT.java
@@ -46,17 +46,24 @@ public class CpuMetricsIT extends MetricCollectorIntegTestBase {
 
     @Test
     public void checkCPUUtilization() throws Exception {
+        checkCPUUtilization(RestConfig.PA_BASE_URI);
+    }
+
+    @Test
+    public void checkLegacyCPUUtilization() throws Exception {
+        checkCPUUtilization(RestConfig.LEGACY_PA_BASE_URI);
+    }
+
+    public void checkCPUUtilization(String paBaseUri) throws Exception {
         // read metric from local node
         List<JsonResponseNode> responseNodeList =
-                readMetric(RestConfig.PA_BASE_URI + "/metrics/?metrics=CPU_Utilization&agg=sum");
+                readMetric(paBaseUri + "/metrics/?metrics=CPU_Utilization&agg=sum");
         Assert.assertEquals(1, responseNodeList.size());
         validatePerNodeCPUMetric(responseNodeList.get(0));
 
         // read metric from all nodes in cluster
         responseNodeList =
-                readMetric(
-                        RestConfig.PA_BASE_URI
-                                + "/metrics/?metrics=CPU_Utilization&agg=sum&nodes=all");
+                readMetric(paBaseUri + "/metrics/?metrics=CPU_Utilization&agg=sum&nodes=all");
         int nodeNum = getNodeIDs().size();
         Assert.assertEquals(nodeNum, responseNodeList.size());
         for (int i = 0; i < nodeNum; i++) {

--- a/src/test/java/org/opensearch/performanceanalyzer/integ_test/HeapMetricsIT.java
+++ b/src/test/java/org/opensearch/performanceanalyzer/integ_test/HeapMetricsIT.java
@@ -59,37 +59,64 @@ public class HeapMetricsIT extends MetricCollectorIntegTestBase {
     @Test
     public void checkHeapInit() throws Exception {
         checkHeapMetric(
-                AllMetrics.HeapValue.HEAP_INIT, (d) -> d >= MIN_HEAP_IN_MB && d <= MAX_HEAP_IN_MB);
+                AllMetrics.HeapValue.HEAP_INIT,
+                (d) -> d >= MIN_HEAP_IN_MB && d <= MAX_HEAP_IN_MB,
+                RestConfig.PA_BASE_URI);
+    }
+
+    @Test
+    public void checkLegacyHeapInit() throws Exception {
+        checkHeapMetric(
+                AllMetrics.HeapValue.HEAP_INIT,
+                (d) -> d >= MIN_HEAP_IN_MB && d <= MAX_HEAP_IN_MB,
+                RestConfig.LEGACY_PA_BASE_URI);
     }
 
     @Test
     public void checkHeapMax() throws Exception {
         checkHeapMetric(
-                AllMetrics.HeapValue.HEAP_MAX, (d) -> d >= MIN_HEAP_IN_MB && d <= MAX_HEAP_IN_MB);
+                AllMetrics.HeapValue.HEAP_MAX,
+                (d) -> d >= MIN_HEAP_IN_MB && d <= MAX_HEAP_IN_MB,
+                RestConfig.PA_BASE_URI);
+    }
+
+    @Test
+    public void checkLegacyHeapMax() throws Exception {
+        checkHeapMetric(
+                AllMetrics.HeapValue.HEAP_MAX,
+                (d) -> d >= MIN_HEAP_IN_MB && d <= MAX_HEAP_IN_MB,
+                RestConfig.LEGACY_PA_BASE_URI);
     }
 
     @Test
     public void checkHeapUsed() throws Exception {
         checkHeapMetric(
-                AllMetrics.HeapValue.HEAP_USED, (d) -> d >= MIN_HEAP_IN_MB && d <= MAX_HEAP_IN_MB);
+                AllMetrics.HeapValue.HEAP_USED,
+                (d) -> d >= MIN_HEAP_IN_MB && d <= MAX_HEAP_IN_MB,
+                RestConfig.PA_BASE_URI);
     }
 
-    private void checkHeapMetric(AllMetrics.HeapValue metric, DoublePredicate metricValidator)
+    @Test
+    public void checkLegacyHeapUsed() throws Exception {
+        checkHeapMetric(
+                AllMetrics.HeapValue.HEAP_USED,
+                (d) -> d >= MIN_HEAP_IN_MB && d <= MAX_HEAP_IN_MB,
+                RestConfig.LEGACY_PA_BASE_URI);
+    }
+
+    private void checkHeapMetric(
+            AllMetrics.HeapValue metric, DoublePredicate metricValidator, String paBaseUri)
             throws Exception {
         // read metric from local node
         List<JsonResponseNode> responseNodeList =
-                readMetric(
-                        RestConfig.PA_BASE_URI
-                                + "/metrics/?metrics="
-                                + metric.toString()
-                                + "&agg=max");
+                readMetric(paBaseUri + "/metrics/?metrics=" + metric.toString() + "&agg=max");
         Assert.assertEquals(1, responseNodeList.size());
         validateHeapMetric(responseNodeList.get(0), metric, metricValidator);
 
         // read metric from all nodes in cluster
         responseNodeList =
                 readMetric(
-                        RestConfig.PA_BASE_URI
+                        paBaseUri
                                 + "/metrics/?metrics="
                                 + metric.toString()
                                 + "&agg=max&nodes=all");

--- a/src/test/java/org/opensearch/performanceanalyzer/integ_test/PageFaultMetricsIT.java
+++ b/src/test/java/org/opensearch/performanceanalyzer/integ_test/PageFaultMetricsIT.java
@@ -46,17 +46,24 @@ public class PageFaultMetricsIT extends MetricCollectorIntegTestBase {
 
     @Test
     public void checkPaging_MajfltRate() throws Exception {
+        checkPaging_MajfltRate(RestConfig.PA_BASE_URI);
+    }
+
+    @Test
+    public void checkLegacyPaging_MajfltRate() throws Exception {
+        checkPaging_MajfltRate(RestConfig.LEGACY_PA_BASE_URI);
+    }
+
+    public void checkPaging_MajfltRate(String paBaseUri) throws Exception {
         // read metric from local node
         List<JsonResponseNode> responseNodeList =
-                readMetric(RestConfig.PA_BASE_URI + "/metrics/?metrics=Paging_MajfltRate&agg=max");
+                readMetric(paBaseUri + "/metrics/?metrics=Paging_MajfltRate&agg=max");
         Assert.assertEquals(1, responseNodeList.size());
         validateMajorPageFaultMetric(responseNodeList.get(0));
 
         // read metric from all nodes in cluster
         responseNodeList =
-                readMetric(
-                        RestConfig.PA_BASE_URI
-                                + "/metrics/?metrics=Paging_MajfltRate&agg=max&nodes=all");
+                readMetric(paBaseUri + "/metrics/?metrics=Paging_MajfltRate&agg=max&nodes=all");
         int nodeNum = getNodeIDs().size();
         Assert.assertEquals(nodeNum, responseNodeList.size());
         for (int i = 0; i < nodeNum; i++) {
@@ -66,17 +73,24 @@ public class PageFaultMetricsIT extends MetricCollectorIntegTestBase {
 
     @Test
     public void checkPaging_MinfltRate() throws Exception {
+        checkPaging_MinfltRate(RestConfig.PA_BASE_URI);
+    }
+
+    @Test
+    public void checkLegacyPaging_MinfltRate() throws Exception {
+        checkPaging_MinfltRate(RestConfig.LEGACY_PA_BASE_URI);
+    }
+
+    public void checkPaging_MinfltRate(String paBaseUri) throws Exception {
         // read metric from local node
         List<JsonResponseNode> responseNodeList =
-                readMetric(RestConfig.PA_BASE_URI + "/metrics/?metrics=Paging_MinfltRate&agg=max");
+                readMetric(paBaseUri + "/metrics/?metrics=Paging_MinfltRate&agg=max");
         Assert.assertEquals(1, responseNodeList.size());
         validateMinorPageFaultMetric(responseNodeList.get(0));
 
         // read metric from all nodes in cluster
         responseNodeList =
-                readMetric(
-                        RestConfig.PA_BASE_URI
-                                + "/metrics/?metrics=Paging_MinfltRate&agg=max&nodes=all");
+                readMetric(paBaseUri + "/metrics/?metrics=Paging_MinfltRate&agg=max&nodes=all");
         int nodeNum = getNodeIDs().size();
         Assert.assertEquals(nodeNum, responseNodeList.size());
         for (int i = 0; i < nodeNum; i++) {
@@ -86,16 +100,23 @@ public class PageFaultMetricsIT extends MetricCollectorIntegTestBase {
 
     @Test
     public void checkPaging_RSS() throws Exception {
+        checkPaging_RSS(RestConfig.PA_BASE_URI);
+    }
+
+    @Test
+    public void checkLegacyPaging_RSS() throws Exception {
+        checkPaging_RSS(RestConfig.LEGACY_PA_BASE_URI);
+    }
+
+    public void checkPaging_RSS(String paBaseUri) throws Exception {
         // read metric from local node
         List<JsonResponseNode> responseNodeList =
-                readMetric(RestConfig.PA_BASE_URI + "/metrics/?metrics=Paging_RSS&agg=max");
+                readMetric(paBaseUri + "/metrics/?metrics=Paging_RSS&agg=max");
         Assert.assertEquals(1, responseNodeList.size());
         validatePagingRSSMetric(responseNodeList.get(0));
 
         // read metric from all nodes in cluster
-        responseNodeList =
-                readMetric(
-                        RestConfig.PA_BASE_URI + "/metrics/?metrics=Paging_RSS&agg=max&nodes=all");
+        responseNodeList = readMetric(paBaseUri + "/metrics/?metrics=Paging_RSS&agg=max&nodes=all");
         int nodeNum = getNodeIDs().size();
         Assert.assertEquals(nodeNum, responseNodeList.size());
         for (int i = 0; i < nodeNum; i++) {


### PR DESCRIPTION
**Is your feature request related to a problem? Please provide an existing Issue # , or describe.**
In order to validate backward compatibility, we want our integration tests to exercise the legacy `/_opendistro` endpoint in addition to the `/_plugins` endpoint.

**Describe the solution you are proposing**
Updating integration tests to run the same tests against both `/_opendistro` and `/_plugins`.

### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [ ] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/performance-analyzer/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
