### PR TITLE
Enabled automated license header checks

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -108,7 +108,7 @@ test {
     systemProperty 'tests.security.manager', 'false'
 }
 
-licenseHeaders.enabled = false
+licenseHeaders.enabled = true
 validateNebulaPom.enabled = false
 
 


### PR DESCRIPTION
### Description
1. Re-enabled the 'licenseHeaders' check in the build.gradle file.
 
### Issues Resolved
Related to - opensearch-project/opensearch-plugins#49
 
### Check List
- [x] Commits are signed as per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/k-NN/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).

Signed-off-by: Ketan Verma <vermketa@amazon.com>