### PR TITLE
Enable ShardIndexingPressureMetricCollector by default

### DIFF
--- a/src/main/java/org/opensearch/performanceanalyzer/collectors/ShardIndexingPressureMetricsCollector.java
+++ b/src/main/java/org/opensearch/performanceanalyzer/collectors/ShardIndexingPressureMetricsCollector.java
@@ -95,10 +95,6 @@ public class ShardIndexingPressureMetricsCollector extends PerformanceAnalyzerMe
     @Override
     @SuppressWarnings("unchecked")
     public void collectMetrics(long startTime) {
-        if (!controller.isCollectorEnabled(configOverridesWrapper, getCollectorName())) {
-            return;
-        }
-
         long mCurrT = System.currentTimeMillis();
         try {
             ClusterService clusterService = OpenSearchResources.INSTANCE.getClusterService();

--- a/src/test/java/org/opensearch/performanceanalyzer/collectors/ShardIndexingPressureMetricsCollectorTests.java
+++ b/src/test/java/org/opensearch/performanceanalyzer/collectors/ShardIndexingPressureMetricsCollectorTests.java
@@ -73,10 +73,7 @@ public class ShardIndexingPressureMetricsCollectorTests extends CustomMetricsLoc
     @Test
     public void testShardIndexingPressureMetrics() {
         long startTimeInMills = 1153721339;
-        Mockito.when(
-                        mockController.isCollectorEnabled(
-                                mockConfigOverrides, "ShardIndexingPressureMetricsCollector"))
-                .thenReturn(true);
+
         shardIndexingPressureMetricsCollector.saveMetricValues(
                 "shard_indexing_pressure_metrics", startTimeInMills);
 


### PR DESCRIPTION
**Desciption**
Enable ShardIndexingPressureMetricCollector by default

### Check List
- [x] New functionality includes testing.
  - [x] All tests pass
- [x] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/performance-analyzer/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
