### PR TITLE
Use Collector override disable list for ShardIndexingPressureMetricCollector

### DIFF
--- a/src/main/java/org/opensearch/performanceanalyzer/collectors/ShardIndexingPressureMetricsCollector.java
+++ b/src/main/java/org/opensearch/performanceanalyzer/collectors/ShardIndexingPressureMetricsCollector.java
@@ -95,7 +95,7 @@ public class ShardIndexingPressureMetricsCollector extends PerformanceAnalyzerMe
     @Override
     @SuppressWarnings("unchecked")
     public void collectMetrics(long startTime) {
-        if (!controller.isCollectorEnabled(configOverridesWrapper, getCollectorName())) {
+        if (controller.isCollectorDisabled(configOverridesWrapper, getCollectorName())) {
             return;
         }
 

--- a/src/main/java/org/opensearch/performanceanalyzer/config/PerformanceAnalyzerController.java
+++ b/src/main/java/org/opensearch/performanceanalyzer/config/PerformanceAnalyzerController.java
@@ -317,4 +317,19 @@ public class PerformanceAnalyzerController {
                         .getCollectors();
         return enabledCollectorsList.contains(collectorName) ? true : false;
     }
+
+    public boolean isCollectorDisabled(
+            ConfigOverridesWrapper configOverridesWrapper, String collectorName) {
+        if (configOverridesWrapper == null) {
+            return true;
+        }
+
+        List<String> disabledCollectorsList =
+                configOverridesWrapper
+                        .getCurrentClusterConfigOverrides()
+                        .getDisable()
+                        .getCollectors();
+
+        return disabledCollectorsList.contains(collectorName);
+    }
 }

--- a/src/test/java/org/opensearch/performanceanalyzer/collectors/ShardIndexingPressureMetricsCollectorTests.java
+++ b/src/test/java/org/opensearch/performanceanalyzer/collectors/ShardIndexingPressureMetricsCollectorTests.java
@@ -73,10 +73,12 @@ public class ShardIndexingPressureMetricsCollectorTests extends CustomMetricsLoc
     @Test
     public void testShardIndexingPressureMetrics() {
         long startTimeInMills = 1153721339;
+
         Mockito.when(
-                        mockController.isCollectorEnabled(
+                        mockController.isCollectorDisabled(
                                 mockConfigOverrides, "ShardIndexingPressureMetricsCollector"))
-                .thenReturn(true);
+                .thenReturn(false);
+
         shardIndexingPressureMetricsCollector.saveMetricValues(
                 "shard_indexing_pressure_metrics", startTimeInMills);
 

--- a/src/test/java/org/opensearch/performanceanalyzer/config/PerformanceAnalyzerControllerTests.java
+++ b/src/test/java/org/opensearch/performanceanalyzer/config/PerformanceAnalyzerControllerTests.java
@@ -27,15 +27,21 @@
 package org.opensearch.performanceanalyzer.config;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
 import static org.mockito.MockitoAnnotations.initMocks;
 
 import java.nio.file.Paths;
+import java.util.Arrays;
+import org.apache.commons.lang3.RandomStringUtils;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
 import org.opensearch.common.settings.Settings;
 import org.opensearch.performanceanalyzer.OpenSearchResources;
 import org.opensearch.performanceanalyzer.collectors.ScheduledMetricCollectorsExecutor;
+import org.opensearch.performanceanalyzer.config.overrides.ConfigOverrides;
+import org.opensearch.performanceanalyzer.config.overrides.ConfigOverridesWrapper;
 
 public class PerformanceAnalyzerControllerTests {
     private static final int NUM_OF_SHARDS_PER_COLLECTION = 1;
@@ -59,5 +65,40 @@ public class PerformanceAnalyzerControllerTests {
 
         controller.updateNodeStatsShardsPerCollection(NUM_OF_SHARDS_PER_COLLECTION);
         assertEquals(NUM_OF_SHARDS_PER_COLLECTION, controller.getNodeStatsShardsPerCollection());
+    }
+
+    @Test
+    public void testCollectorIsDisabledIfPresentInDisabledConfigOverride() {
+        ConfigOverridesWrapper configOverridesWrapper = new ConfigOverridesWrapper();
+        ConfigOverrides configOverrides = new ConfigOverrides();
+
+        String collectorName = RandomStringUtils.randomAlphabetic(10);
+
+        ConfigOverrides.Overrides overrides = new ConfigOverrides.Overrides();
+        overrides.setCollectors(Arrays.asList(collectorName));
+        configOverrides.setDisable(overrides);
+        configOverridesWrapper.setCurrentClusterConfigOverrides(configOverrides);
+
+        assertTrue(controller.isCollectorDisabled(configOverridesWrapper, collectorName));
+    }
+
+    @Test
+    public void testCollectorIsNotDisabledIfNotPresentInDisabledConfigOverride() {
+        ConfigOverridesWrapper configOverridesWrapper = new ConfigOverridesWrapper();
+        ConfigOverrides configOverrides = new ConfigOverrides();
+
+        String collectorName = RandomStringUtils.randomAlphabetic(10);
+
+        ConfigOverrides.Overrides overrides = new ConfigOverrides.Overrides();
+        configOverrides.setDisable(overrides);
+        configOverridesWrapper.setCurrentClusterConfigOverrides(configOverrides);
+
+        assertFalse(controller.isCollectorDisabled(configOverridesWrapper, collectorName));
+    }
+
+    @Test
+    public void testCollectorIsDisabledIfConfigOverrideIsNotProvided() {
+        String collectorName = RandomStringUtils.randomAlphabetic(10);
+        assertTrue(controller.isCollectorDisabled(null, collectorName));
     }
 }


### PR DESCRIPTION
**Description**
Use Collector override disable list for `ShardIndexingPressureMetricCollector`. With this change `ShardIndexingPressureMetricCollector` will be enabled by default with the controls to disable it dynamically

### Check List
- [x] New functionality includes testing.
  - [x] All tests pass
- [x] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/performance-analyzer/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
