### PR TITLE
Create writer file if metrics are available

### DIFF
--- a/src/main/java/org/opensearch/performanceanalyzer/writer/EventLogQueueProcessor.java
+++ b/src/main/java/org/opensearch/performanceanalyzer/writer/EventLogQueueProcessor.java
@@ -172,8 +172,11 @@ public class EventLogQueueProcessor {
         if (lastTimeBucket != 0 && lastTimeBucket != currTimeBucket) {
             eventLogFileHandler.renameFromTmp(lastTimeBucket);
         }
-        // This appends the data to a file named <currTimeBucket>.tmp
-        eventLogFileHandler.writeTmpFile(currMetrics, currTimeBucket);
+        // Append to the tmp file only if we have metrics to publish.
+        if (!currMetrics.isEmpty()) {
+            // This appends the data to a file named <currTimeBucket>.tmp
+            eventLogFileHandler.writeTmpFile(currMetrics, currTimeBucket);
+        }
         lastTimeBucket = currTimeBucket;
     }
 }


### PR DESCRIPTION
Signed-off-by: Sruti Parthiban <partsrut@amazon.com>

**Is your feature request related to a problem? Please provide an existing Issue # , or describe.**
https://github.com/opensearch-project/performance-analyzer/issues/30

**Describe the solution you are proposing**
We write to tmp files first before renaming to actual epoch file. 
Append/ Create to the tmp file only if we have metrics to publish.

**Describe alternatives you've considered**
A clear and concise description of any alternative solutions or features you've considered.

**Additional context**
Add any other context or screenshots about the feature request here.

### Check List
- [x] New functionality includes testing.
  - [ ] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [x] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/performance-analyzer/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
