### PR TITLE
Handling purging of lingering files before scheduleExecutor start.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 [![Java CI](https://github.com/opensearch-project/performance-analyzer/workflows/Java%20CI/badge.svg)](https://github.com/opensearch-project/performance-analyzer/actions?query=workflow%3A%22Java+CI%22)
 [![CD](https://github.com/opensearch-project/performance-analyzer/workflows/CD/badge.svg)](https://github.com/opensearch-project/performance-analyzer/actions?query=workflow%3ACD)
 [![codecov](https://codecov.io/gh/opensearch-project/performance-analyzer/branch/main/graph/badge.svg)](https://codecov.io/gh/opensearch-project/performance-analyzer)
-[![Documentation](https://img.shields.io/badge/api-reference-blue.svg)](https://docs-beta.opensearch.org/monitoring-plugins/pa/api/)
+[![Documentation](https://img.shields.io/badge/api-reference-blue.svg)](https://opensearch.org/docs/monitoring-plugins/pa/api/)
 [![Chat](https://img.shields.io/badge/chat-on%20forums-blue)](https://discuss.opendistrocommunity.dev/c/performance-analyzer/)
 ![PRs welcome!](https://img.shields.io/badge/PRs-welcome!-success)
 
@@ -96,7 +96,7 @@ See the [design doc](https://github.com/opensearch-project/performance-analyzer-
 
 ## Documentation
 
-Please refer to the [technical documentation](https://docs-beta.opensearch.org/monitoring-plugins/pa/index/) for detailed information on installing and configuring Performance Analyzer.
+Please refer to the [technical documentation](https://opensearch.org/docs/monitoring-plugins/pa/index/) for detailed information on installing and configuring Performance Analyzer.
 
 ## Contributing
 

--- a/build.gradle
+++ b/build.gradle
@@ -486,7 +486,7 @@ afterEvaluate {
         url 'https://opensearch.org/downloads.html'
         summary '''
          Performance Analyzer plugin for OpenSearch.
-         Reference documentation can be found at https://docs-beta.opensearch.org/.
+         Reference documentation can be found at https://opensearch.org/docs/.
     '''.stripIndent().replace('\n', ' ').trim()
     }
 

--- a/src/main/java/org/opensearch/performanceanalyzer/writer/EventLogQueueProcessor.java
+++ b/src/main/java/org/opensearch/performanceanalyzer/writer/EventLogQueueProcessor.java
@@ -80,7 +80,7 @@ public class EventLogQueueProcessor {
         // Cleanup any lingering files from previous plugin run.
         try {
             eventLogFileHandler.deleteAllFiles();
-        } catch Exception ex {
+        } catch (Exception ex) {
             LOG.error("Unable to cleanup lingering files from previous plugin run.", ex);
         }
         lastCleanupTimeBucket = PerformanceAnalyzerMetrics.getTimeInterval(System.currentTimeMillis());

--- a/src/main/java/org/opensearch/performanceanalyzer/writer/EventLogQueueProcessor.java
+++ b/src/main/java/org/opensearch/performanceanalyzer/writer/EventLogQueueProcessor.java
@@ -77,6 +77,14 @@ public class EventLogQueueProcessor {
     }
 
     public void scheduleExecutor() {
+        // Cleanup any lingering files from previous plugin run.
+        try {
+            eventLogFileHandler.deleteAllFiles();
+        } catch Exception ex {
+            LOG.error("Unable to cleanup lingering files from previous plugin run.", ex);
+        }
+        lastCleanupTimeBucket = PerformanceAnalyzerMetrics.getTimeInterval(System.currentTimeMillis());
+
         ScheduledFuture<?> futureHandle =
                 writerExecutor.scheduleAtFixedRate(
                         this::purgeQueueAndPersist,
@@ -179,23 +187,16 @@ public class EventLogQueueProcessor {
     }
 
     private void cleanup() {
-        long currentTimeMillis = System.currentTimeMillis();
-        if (lastCleanupTimeBucket != 0) {
-            // Delete Event log files belonging to time bucket older than past filesCleanupPeriod(defaults to 60s)
-            long currCleanupTimeBucket = PerformanceAnalyzerMetrics.getTimeInterval(currentTimeMillis);
-            if (currCleanupTimeBucket - lastCleanupTimeBucket > filesCleanupPeriodicityMillis) {
-                // Get list of files(time buckets) for purging, considered range : [lastCleanupTimeBucket, currCleanupTimeBucket)
-                List<String> filesForCleanup = LongStream.range(lastCleanupTimeBucket, currCleanupTimeBucket)
-                        .filter(timeMillis -> timeMillis % MetricsConfiguration.SAMPLING_INTERVAL == 0)
-                        .mapToObj(String::valueOf)
-                        .collect(Collectors.toList());
-                eventLogFileHandler.deleteFiles(Collections.unmodifiableList(filesForCleanup));
-                lastCleanupTimeBucket = currCleanupTimeBucket;
-            }
-        } else {
-            // First purge since the start-up, cleanup any lingering files.
-            eventLogFileHandler.deleteAllFiles();
-            lastCleanupTimeBucket = PerformanceAnalyzerMetrics.getTimeInterval(currentTimeMillis);
+        // Delete Event log files belonging to time bucket older than past filesCleanupPeriod(defaults to 60s)
+        long currCleanupTimeBucket = PerformanceAnalyzerMetrics.getTimeInterval(System.currentTimeMillis());
+        if (currCleanupTimeBucket - lastCleanupTimeBucket > filesCleanupPeriodicityMillis) {
+            // Get list of files(time buckets) for purging, considered range : [lastCleanupTimeBucket, currCleanupTimeBucket)
+            List<String> filesForCleanup = LongStream.range(lastCleanupTimeBucket, currCleanupTimeBucket)
+                    .filter(timeMillis -> timeMillis % MetricsConfiguration.SAMPLING_INTERVAL == 0)
+                    .mapToObj(String::valueOf)
+                    .collect(Collectors.toList());
+            eventLogFileHandler.deleteFiles(Collections.unmodifiableList(filesForCleanup));
+            lastCleanupTimeBucket = currCleanupTimeBucket;
         }
     }
 


### PR DESCRIPTION
**Is your feature request related to a problem? Please provide an existing Issue # , or describe.**
1. Addresses Joydeep's comment on [PR-36](https://github.com/opensearch-project/performance-analyzer/pull/36). Moved deleteAllFiles() to inside scheduleExecutor(), this ensures that deleteAllFiles() is invoked once and before beginning of event log file generation. 
2. Minor change around fixing the official documentation to resolve Link Checker errors.

**Describe the solution you are proposing**
A clear and concise description of what you want to happen.

**Describe alternatives you've considered**
A clear and concise description of any alternative solutions or features you've considered.

**Additional context**
Add any other context or screenshots about the feature request here.

### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [ ] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/performance-analyzer/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
