### PR TITLE
Fixes typo in APIs to enable PA batch metrics API in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,8 +52,8 @@ While the metrics api associated with performance analyzer provides the last 5 s
 In order to access the batch metrics api, first enable it using one of the following HTTP request:
 
 ```
-POST localhost:9200/_plugins/performanceanalyzer/batch/config -H ‘Content-Type: application/json’ -d ‘{"enabled": true}’
-POST localhost:9200/_plugins/performanceanalyzer/batch/cluster/config -H ‘Content-Type: application/json’ -d ‘{"enabled": true}’
+POST localhost:9200/_plugins/_performanceanalyzer/batch/config -H ‘Content-Type: application/json’ -d ‘{"enabled": true}’
+POST localhost:9200/_plugins/_performanceanalyzer/batch/cluster/config -H ‘Content-Type: application/json’ -d ‘{"enabled": true}’
 ```
 
 The former enables batch metrics on a single node, while the latter enables it on nodes across the entire cluster. Batch metrics can be disabled using analogous queries with `{"enabled": false}`.


### PR DESCRIPTION
Fixes typo in apis to enable PA batch metrics API in README.md

**Is your feature request related to a problem? Please provide an existing Issue # , or describe.**
There is a typo in the apis to enable batch metrics for cluster and node.

**Describe the solution you are proposing**
Typo fix

### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [ ] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/performance-analyzer/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
