### PR TITLE
Refactor stats collector

### DIFF
--- a/src/main/java/org/opensearch/performanceanalyzer/collectors/MasterServiceEventMetrics.java
+++ b/src/main/java/org/opensearch/performanceanalyzer/collectors/MasterServiceEventMetrics.java
@@ -41,12 +41,14 @@ import org.opensearch.cluster.service.MasterService;
 import org.opensearch.cluster.service.SourcePrioritizedRunnable;
 import org.opensearch.common.util.concurrent.PrioritizedOpenSearchThreadPoolExecutor;
 import org.opensearch.performanceanalyzer.OpenSearchResources;
+import org.opensearch.performanceanalyzer.PerformanceAnalyzerApp;
 import org.opensearch.performanceanalyzer.metrics.AllMetrics.MasterMetricDimensions;
 import org.opensearch.performanceanalyzer.metrics.AllMetrics.MasterMetricValues;
 import org.opensearch.performanceanalyzer.metrics.MetricsConfiguration;
 import org.opensearch.performanceanalyzer.metrics.MetricsProcessor;
 import org.opensearch.performanceanalyzer.metrics.PerformanceAnalyzerMetrics;
 import org.opensearch.performanceanalyzer.metrics.ThreadIDUtil;
+import org.opensearch.performanceanalyzer.rca.framework.metrics.WriterMetrics;
 
 @SuppressWarnings("unchecked")
 public class MasterServiceEventMetrics extends PerformanceAnalyzerMetricsCollector
@@ -54,7 +56,6 @@ public class MasterServiceEventMetrics extends PerformanceAnalyzerMetricsCollect
     public static final int SAMPLING_TIME_INTERVAL =
             MetricsConfiguration.CONFIG_MAP.get(MasterServiceEventMetrics.class).samplingInterval;
     private static final Logger LOG = LogManager.getLogger(MasterServiceEventMetrics.class);
-    private static final String MASTER_NODE_NOT_UP_METRIC = "MasterNodeNotUp";
     private static final int KEYS_PATH_LENGTH = 3;
     private StringBuilder value;
     private static final int TPEXECUTOR_ADD_PENDING_PARAM_COUNT = 3;
@@ -169,7 +170,8 @@ public class MasterServiceEventMetrics extends PerformanceAnalyzerMetricsCollect
             }
             LOG.debug(() -> "Successfully collected Master Event Metrics.");
         } catch (Exception ex) {
-            StatsCollector.instance().logException(StatExceptionCode.MASTER_METRICS_ERROR);
+            PerformanceAnalyzerApp.WRITER_METRICS_AGGREGATOR.updateStat(
+                    WriterMetrics.MASTER_METRICS_ERROR, "", 1);
             LOG.debug(
                     "Exception in Collecting Master Metrics: {} for startTime {} with ExceptionCode: {}",
                     () -> ex.toString(),
@@ -251,7 +253,8 @@ public class MasterServiceEventMetrics extends PerformanceAnalyzerMetricsCollect
                                         getPrioritizedTPExecutorCurrentField()
                                                 .get(prioritizedOpenSearchThreadPoolExecutor);
                     } else {
-                        StatsCollector.instance().logMetric(MASTER_NODE_NOT_UP_METRIC);
+                        PerformanceAnalyzerApp.WRITER_METRICS_AGGREGATOR.updateStat(
+                                WriterMetrics.MASTER_NODE_NOT_UP, "", 1);
                     }
                 }
             }

--- a/src/main/java/org/opensearch/performanceanalyzer/collectors/NodeStatsAllShardsMetricsCollector.java
+++ b/src/main/java/org/opensearch/performanceanalyzer/collectors/NodeStatsAllShardsMetricsCollector.java
@@ -43,11 +43,13 @@ import org.opensearch.index.shard.ShardId;
 import org.opensearch.indices.IndicesService;
 import org.opensearch.indices.NodeIndicesStats;
 import org.opensearch.performanceanalyzer.OpenSearchResources;
+import org.opensearch.performanceanalyzer.PerformanceAnalyzerApp;
 import org.opensearch.performanceanalyzer.config.PerformanceAnalyzerController;
 import org.opensearch.performanceanalyzer.metrics.AllMetrics.ShardStatsValue;
 import org.opensearch.performanceanalyzer.metrics.MetricsConfiguration;
 import org.opensearch.performanceanalyzer.metrics.MetricsProcessor;
 import org.opensearch.performanceanalyzer.metrics.PerformanceAnalyzerMetrics;
+import org.opensearch.performanceanalyzer.rca.framework.metrics.ExceptionsAndErrors;
 import org.opensearch.performanceanalyzer.util.Utils;
 
 /**
@@ -199,7 +201,8 @@ public class NodeStatsAllShardsMetricsCollector extends PerformanceAnalyzerMetri
                     () -> ex.toString(),
                     () -> startTime,
                     () -> StatExceptionCode.NODESTATS_COLLECTION_ERROR.toString());
-            StatsCollector.instance().logException(StatExceptionCode.NODESTATS_COLLECTION_ERROR);
+            PerformanceAnalyzerApp.ERRORS_AND_EXCEPTIONS_AGGREGATOR.updateStat(
+                    ExceptionsAndErrors.NODESTATS_COLLECTION_ERROR, "", 1);
         }
     }
 

--- a/src/main/java/org/opensearch/performanceanalyzer/collectors/NodeStatsFixedShardsMetricsCollector.java
+++ b/src/main/java/org/opensearch/performanceanalyzer/collectors/NodeStatsFixedShardsMetricsCollector.java
@@ -43,11 +43,13 @@ import org.opensearch.index.shard.ShardId;
 import org.opensearch.indices.IndicesService;
 import org.opensearch.indices.NodeIndicesStats;
 import org.opensearch.performanceanalyzer.OpenSearchResources;
+import org.opensearch.performanceanalyzer.PerformanceAnalyzerApp;
 import org.opensearch.performanceanalyzer.config.PerformanceAnalyzerController;
 import org.opensearch.performanceanalyzer.metrics.AllMetrics.ShardStatsValue;
 import org.opensearch.performanceanalyzer.metrics.MetricsConfiguration;
 import org.opensearch.performanceanalyzer.metrics.MetricsProcessor;
 import org.opensearch.performanceanalyzer.metrics.PerformanceAnalyzerMetrics;
+import org.opensearch.performanceanalyzer.rca.framework.metrics.ExceptionsAndErrors;
 import org.opensearch.performanceanalyzer.util.Utils;
 
 /**
@@ -266,7 +268,8 @@ public class NodeStatsFixedShardsMetricsCollector extends PerformanceAnalyzerMet
                     () -> ex.toString(),
                     () -> startTime,
                     () -> StatExceptionCode.NODESTATS_COLLECTION_ERROR.toString());
-            StatsCollector.instance().logException(StatExceptionCode.NODESTATS_COLLECTION_ERROR);
+            PerformanceAnalyzerApp.ERRORS_AND_EXCEPTIONS_AGGREGATOR.updateStat(
+                    ExceptionsAndErrors.NODESTATS_COLLECTION_ERROR, "", 1);
         }
     }
 

--- a/src/main/java/org/opensearch/performanceanalyzer/config/PerformanceAnalyzerController.java
+++ b/src/main/java/org/opensearch/performanceanalyzer/config/PerformanceAnalyzerController.java
@@ -37,12 +37,12 @@ import java.util.Scanner;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.opensearch.performanceanalyzer.OpenSearchResources;
+import org.opensearch.performanceanalyzer.PerformanceAnalyzerApp;
 import org.opensearch.performanceanalyzer.PerformanceAnalyzerPlugin;
 import org.opensearch.performanceanalyzer.collectors.ScheduledMetricCollectorsExecutor;
-import org.opensearch.performanceanalyzer.collectors.StatExceptionCode;
-import org.opensearch.performanceanalyzer.collectors.StatsCollector;
 import org.opensearch.performanceanalyzer.config.overrides.ConfigOverridesWrapper;
 import org.opensearch.performanceanalyzer.metrics.PerformanceAnalyzerMetrics;
+import org.opensearch.performanceanalyzer.rca.framework.metrics.ExceptionsAndErrors;
 
 public class PerformanceAnalyzerController {
     private static final String PERFORMANCE_ANALYZER_ENABLED_CONF =
@@ -292,8 +292,8 @@ public class PerformanceAnalyzerController {
                     try {
                         Path destDir = Paths.get(getDataDirectory());
                         if (!Files.exists(destDir)) {
-                            StatsCollector.instance()
-                                    .logException(StatExceptionCode.CONFIG_DIR_NOT_FOUND);
+                            PerformanceAnalyzerApp.ERRORS_AND_EXCEPTIONS_AGGREGATOR.updateStat(
+                                    ExceptionsAndErrors.CONFIG_DIR_NOT_FOUND, "", 1);
                             Files.createDirectory(destDir);
                         }
                         Files.write(

--- a/src/main/java/org/opensearch/performanceanalyzer/config/setting/ClusterSettingsManager.java
+++ b/src/main/java/org/opensearch/performanceanalyzer/config/setting/ClusterSettingsManager.java
@@ -44,8 +44,8 @@ import org.opensearch.cluster.ClusterStateListener;
 import org.opensearch.common.settings.Setting;
 import org.opensearch.common.settings.Settings;
 import org.opensearch.performanceanalyzer.OpenSearchResources;
-import org.opensearch.performanceanalyzer.collectors.StatExceptionCode;
-import org.opensearch.performanceanalyzer.collectors.StatsCollector;
+import org.opensearch.performanceanalyzer.PerformanceAnalyzerApp;
+import org.opensearch.performanceanalyzer.rca.framework.metrics.WriterMetrics;
 
 /**
  * Class that handles updating cluster settings, and notifying the listeners when cluster settings
@@ -245,8 +245,8 @@ public class ClusterSettingsManager implements ClusterStateListener {
             }
         } catch (Exception ex) {
             LOG.error(ex);
-            StatsCollector.instance()
-                    .logException(StatExceptionCode.OPENSEARCH_REQUEST_INTERCEPTOR_ERROR);
+            PerformanceAnalyzerApp.WRITER_METRICS_AGGREGATOR.updateStat(
+                    WriterMetrics.OPENSEARCH_REQUEST_INTERCEPTOR_ERROR, "", 1);
         }
     }
 
@@ -267,8 +267,8 @@ public class ClusterSettingsManager implements ClusterStateListener {
             }
         } catch (Exception ex) {
             LOG.error(ex);
-            StatsCollector.instance()
-                    .logException(StatExceptionCode.OPENSEARCH_REQUEST_INTERCEPTOR_ERROR);
+            PerformanceAnalyzerApp.WRITER_METRICS_AGGREGATOR.updateStat(
+                    WriterMetrics.OPENSEARCH_REQUEST_INTERCEPTOR_ERROR, "", 1);
         }
     }
     /** Class that handles response to GET /_cluster/settings */

--- a/src/main/java/org/opensearch/performanceanalyzer/listener/PerformanceAnalyzerSearchListener.java
+++ b/src/main/java/org/opensearch/performanceanalyzer/listener/PerformanceAnalyzerSearchListener.java
@@ -30,14 +30,14 @@ package org.opensearch.performanceanalyzer.listener;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.opensearch.index.shard.SearchOperationListener;
-import org.opensearch.performanceanalyzer.collectors.StatExceptionCode;
-import org.opensearch.performanceanalyzer.collectors.StatsCollector;
+import org.opensearch.performanceanalyzer.PerformanceAnalyzerApp;
 import org.opensearch.performanceanalyzer.config.PerformanceAnalyzerController;
 import org.opensearch.performanceanalyzer.metrics.AllMetrics.CommonDimension;
 import org.opensearch.performanceanalyzer.metrics.AllMetrics.CommonMetric;
 import org.opensearch.performanceanalyzer.metrics.MetricsProcessor;
 import org.opensearch.performanceanalyzer.metrics.PerformanceAnalyzerMetrics;
 import org.opensearch.performanceanalyzer.metrics.ThreadIDUtil;
+import org.opensearch.performanceanalyzer.rca.framework.metrics.WriterMetrics;
 import org.opensearch.search.internal.SearchContext;
 
 public class PerformanceAnalyzerSearchListener
@@ -68,8 +68,8 @@ public class PerformanceAnalyzerSearchListener
             getSearchListener().preQueryPhase(searchContext);
         } catch (Exception ex) {
             LOG.error(ex);
-            StatsCollector.instance()
-                    .logException(StatExceptionCode.OPENSEARCH_REQUEST_INTERCEPTOR_ERROR);
+            PerformanceAnalyzerApp.WRITER_METRICS_AGGREGATOR.updateStat(
+                    WriterMetrics.OPENSEARCH_REQUEST_INTERCEPTOR_ERROR, "", 1);
         }
     }
 
@@ -79,8 +79,8 @@ public class PerformanceAnalyzerSearchListener
             getSearchListener().queryPhase(searchContext, tookInNanos);
         } catch (Exception ex) {
             LOG.error(ex);
-            StatsCollector.instance()
-                    .logException(StatExceptionCode.OPENSEARCH_REQUEST_INTERCEPTOR_ERROR);
+            PerformanceAnalyzerApp.WRITER_METRICS_AGGREGATOR.updateStat(
+                    WriterMetrics.OPENSEARCH_REQUEST_INTERCEPTOR_ERROR, "", 1);
         }
     }
 
@@ -90,8 +90,8 @@ public class PerformanceAnalyzerSearchListener
             getSearchListener().failedQueryPhase(searchContext);
         } catch (Exception ex) {
             LOG.error(ex);
-            StatsCollector.instance()
-                    .logException(StatExceptionCode.OPENSEARCH_REQUEST_INTERCEPTOR_ERROR);
+            PerformanceAnalyzerApp.WRITER_METRICS_AGGREGATOR.updateStat(
+                    WriterMetrics.OPENSEARCH_REQUEST_INTERCEPTOR_ERROR, "", 1);
         }
     }
 
@@ -101,8 +101,8 @@ public class PerformanceAnalyzerSearchListener
             getSearchListener().preFetchPhase(searchContext);
         } catch (Exception ex) {
             LOG.error(ex);
-            StatsCollector.instance()
-                    .logException(StatExceptionCode.OPENSEARCH_REQUEST_INTERCEPTOR_ERROR);
+            PerformanceAnalyzerApp.WRITER_METRICS_AGGREGATOR.updateStat(
+                    WriterMetrics.OPENSEARCH_REQUEST_INTERCEPTOR_ERROR, "", 1);
         }
     }
 
@@ -112,8 +112,8 @@ public class PerformanceAnalyzerSearchListener
             getSearchListener().fetchPhase(searchContext, tookInNanos);
         } catch (Exception ex) {
             LOG.error(ex);
-            StatsCollector.instance()
-                    .logException(StatExceptionCode.OPENSEARCH_REQUEST_INTERCEPTOR_ERROR);
+            PerformanceAnalyzerApp.WRITER_METRICS_AGGREGATOR.updateStat(
+                    WriterMetrics.OPENSEARCH_REQUEST_INTERCEPTOR_ERROR, "", 1);
         }
     }
 
@@ -123,8 +123,8 @@ public class PerformanceAnalyzerSearchListener
             getSearchListener().failedFetchPhase(searchContext);
         } catch (Exception ex) {
             LOG.error(ex);
-            StatsCollector.instance()
-                    .logException(StatExceptionCode.OPENSEARCH_REQUEST_INTERCEPTOR_ERROR);
+            PerformanceAnalyzerApp.WRITER_METRICS_AGGREGATOR.updateStat(
+                    WriterMetrics.OPENSEARCH_REQUEST_INTERCEPTOR_ERROR, "", 1);
         }
     }
 

--- a/src/main/java/org/opensearch/performanceanalyzer/transport/PerformanceAnalyzerTransportRequestHandler.java
+++ b/src/main/java/org/opensearch/performanceanalyzer/transport/PerformanceAnalyzerTransportRequestHandler.java
@@ -32,9 +32,9 @@ import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.opensearch.action.bulk.BulkShardRequest;
 import org.opensearch.action.support.replication.TransportReplicationAction.ConcreteShardRequest;
-import org.opensearch.performanceanalyzer.collectors.StatExceptionCode;
-import org.opensearch.performanceanalyzer.collectors.StatsCollector;
+import org.opensearch.performanceanalyzer.PerformanceAnalyzerApp;
 import org.opensearch.performanceanalyzer.config.PerformanceAnalyzerController;
+import org.opensearch.performanceanalyzer.rca.framework.metrics.WriterMetrics;
 import org.opensearch.tasks.Task;
 import org.opensearch.transport.TransportChannel;
 import org.opensearch.transport.TransportRequest;
@@ -114,8 +114,8 @@ public class PerformanceAnalyzerTransportRequestHandler<T extends TransportReque
                 LOG.error(ex);
                 logOnce = true;
             }
-            StatsCollector.instance()
-                    .logException(StatExceptionCode.OPENSEARCH_REQUEST_INTERCEPTOR_ERROR);
+            PerformanceAnalyzerApp.WRITER_METRICS_AGGREGATOR.updateStat(
+                    WriterMetrics.OPENSEARCH_REQUEST_INTERCEPTOR_ERROR, "", 1);
         }
 
         return performanceanalyzerChannel;

--- a/src/test/java/org/opensearch/performanceanalyzer/collectors/StatsTests.java
+++ b/src/test/java/org/opensearch/performanceanalyzer/collectors/StatsTests.java
@@ -65,13 +65,11 @@ public class StatsTests {
     private static final int REQUEST_REMOTE_ERRORS = Math.abs(RANDOM.nextInt() % MAX_COUNT);
     private static final int READER_PARSER_ERRORS = Math.abs(RANDOM.nextInt() % MAX_COUNT);
     private static final int READER_RESTART_PROCESSINGS = Math.abs(RANDOM.nextInt() % MAX_COUNT);
-    private static final int OTHERS = Math.abs(RANDOM.nextInt() % MAX_COUNT);
     private static final int TOTAL_ERRORS =
             MASTER_METRICS_ERRORS
                     + REQUEST_REMOTE_ERRORS
                     + READER_PARSER_ERRORS
-                    + READER_RESTART_PROCESSINGS
-                    + OTHERS;
+                    + READER_RESTART_PROCESSINGS;
     private static final AtomicInteger DEFAULT_VAL = new AtomicInteger(0);
     private static final int EXEC_COUNT = 20;
 
@@ -95,10 +93,6 @@ public class StatsTests {
 
         for (int i = 0; i < READER_RESTART_PROCESSINGS; i++) {
             exceptionCodeList.add(StatExceptionCode.READER_RESTART_PROCESSING);
-        }
-
-        for (int i = 0; i < OTHERS; i++) {
-            exceptionCodeList.add(null);
         }
 
         Collections.shuffle(exceptionCodeList);
@@ -143,11 +137,6 @@ public class StatsTests {
                                 StatExceptionCode.READER_RESTART_PROCESSING.toString(), DEFAULT_VAL)
                         .get(),
                 READER_RESTART_PROCESSINGS);
-        assertEquals(
-                sc.getCounters()
-                        .getOrDefault(StatExceptionCode.OTHER.toString(), DEFAULT_VAL)
-                        .get(),
-                OTHERS);
         assertEquals(
                 sc.getCounters()
                         .getOrDefault(StatExceptionCode.TOTAL_ERROR.toString(), DEFAULT_VAL)
@@ -195,8 +184,6 @@ public class StatsTests {
 
             if (exceptionCode != null) {
                 sc.logException(exceptionCode);
-            } else {
-                sc.logException();
             }
             count++;
         }


### PR DESCRIPTION
Signed-off-by: Sruti Parthiban <partsrut@amazon.com>

**Is your feature request related to a problem? Please provide an existing Issue # , or describe.**
StatsCollector is used by RCA-Agent and PerformanceAnalyzer Plugin to publish service metrics. We run this collector through ScheduledMetricCollectorsExecutor and the executor can mark the collector as SLOW and subsequently MUTED if the collector is slow. A muted collector doesn't emit any metrics and thus we can end up missing the helpful service metrics.

This PR contains changes to skip muting for StatsCollector and re-factoring to move away from StatExceptionCode to Metric Aggregators.

This is an extension of this PR https://github.com/opensearch-project/performance-analyzer-rca/pull/37.

**Describe the solution you are proposing**
A clear and concise description of what you want to happen.

**Describe alternatives you've considered**
A clear and concise description of any alternative solutions or features you've considered.

**Additional context**
Add any other context or screenshots about the feature request here.

### Check List
- [x] New functionality includes testing.
  - [ ] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [x] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/performance-analyzer/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
