### PR TITLE
Remove dependency on main branch when running spotless.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -88,9 +88,6 @@ ext {
 
 spotless {
     java {
-        // only apply formatting rules to updated files
-        ratchetFrom "origin/${gitDefaultBranch}"
-
         licenseHeaderFile(file('license-header'))
         googleJavaFormat().aosp()
         importOrder()


### PR DESCRIPTION
Signed-off-by: Marc Handalian <handalm@amazon.com>

This change removes the main branch as a dependency when running spotless.
The spotless check will not compare for changes against main and will check every file when building a branch.

closes #44 

### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [ x] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/performance-analyzer/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
