### PR TITLE
Fix build to succeed with opensearch_version provided

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -348,12 +348,9 @@ task buildRca() {
             workingDir("$licenseDir")
             commandLine 'rm', "-f", "performanceanalyzer-rca-1.0.0.0.jar.sha1"
         }
-        exec {
-            workingDir("$projectDir")
-            commandLine './gradlew', 'updateShas'
-        }
     }
 }
+buildRca.finalizedBy updateShas
 
 // This value is set by the unpackRca task
 def rcaArtifactsDir


### PR DESCRIPTION
Signed-off-by: Marc Handalian <handalm@amazon.com>

**Is your feature request related to a problem? Please provide an existing Issue # , or describe.**
The build is failing when opensearch version specified is not the same as the default value.

**Describe the solution you are proposing**
The cause of this problem is updateShas is invoked, which is a task in this project, during the doLast step of the buildRCA task.  This task is not invoked with any properties passed in during the initial build command.
This change will execute this directly with finalizedBy instead of using doLast and executing from the command line.

**Describe alternatives you've considered**
passing the version string down to doLast.  I would rather directly invoke the task without executing from shell.

closes #51 

### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [ x] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/performance-analyzer/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
