### PR TITLE
Fix snapshot build using OpenSearch 1.1.

### DIFF
--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -13,18 +13,10 @@ jobs:
     runs-on: [ubuntu-latest]
     name: Building PA package
     steps:
-    - name: Checkout Performance Analyzer package
-      uses: actions/checkout@v2
-      with:
-        path: ./tmp/pa
-      # fetch the main branch to make it available for spotless ratcheting
-    - name: Fetch 'main' branch
-      working-directory:  ./tmp/pa
-      run: git fetch --depth=1 origin main
-    - name: Set up JDK 1.12
+    - name: Set up JDK
       uses: actions/setup-java@v1
       with:
-        java-version: 1.12
+        java-version: 14
     # dependencies: OpenSearch
     - name: Checkout OpenSearch
       uses: actions/checkout@v2
@@ -34,7 +26,13 @@ jobs:
         ref: '1.x'
     - name: Build OpenSearch
       working-directory: ./OpenSearch
-      run: ./gradlew publishToMavenLocal -Dopensearch.version=1.1.0-SNAPSHOT
+      run: ./gradlew publishToMavenLocal
+
+    # Performance Analyzer in ./tmp/performance-analyzer
+    - name: Checkout Performance Analyzer package
+      uses: actions/checkout@v2
+      with:
+        path: ./tmp/performance-analyzer
       # Explicitly set the docker-compose program path so that our build scripts in RCA can run the program
       # This is necessary because of the Github Actions environment and the workingDir of the Gradle environment
     - name: Set docker-compose path
@@ -42,17 +40,21 @@ jobs:
       # Set the vm.max_map_count system property to the minimum required to run OpenSearch
     - name: Set vm.max_map_count
       run: sudo sysctl -w vm.max_map_count=262144
-    - name: Build PA and run Unit Tests
-      working-directory: ./tmp/pa
-      run: ./gradlew build -Dperformance-analyzer-rca.build=true -Dperformance-analyzer-rca.branch=main -Dopensearch.version=1.1.0-SNAPSHOT
+    - name: Build Performance Analyzer and run Unit Tests
+      working-directory: ./tmp/performance-analyzer
+      run: |
+        ./gradlew build -Dperformance-analyzer-rca.build=true \
+          -Dperformance-analyzer-rca.repo="https://github.com/dblock/performance-analyzer-rca.git" \
+          -Dperformance-analyzer-rca.branch=fix-snapshot-build \
+          -Dopensearch.version=1.1.0-SNAPSHOT
     - name: Generate Jacoco coverage report
-      working-directory: ./tmp/pa
+      working-directory: ./tmp/performance-analyzer
       run: ./gradlew jacocoTestReport
     - name: Upload coverage report
-      working-directory: ./tmp/pa
+      working-directory: ./tmp/performance-analyzer
       env:
         CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
       run: bash <(curl -s https://codecov.io/bash) -f ./build/reports/jacoco/test/jacocoTestReport.xml
     - name: Run Integration Tests
-      working-directory: ./tmp/pa
+      working-directory: ./tmp/performance-analyzer
       run: ./gradlew integTest -Dtests.enableIT -Dtests.useDockerCluster -Dopensearch.version=1.1.0-SNAPSHOT

--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -31,10 +31,10 @@ jobs:
       with:
         repository: 'opensearch-project/OpenSearch'
         path: OpenSearch
-        ref: '1.0'
+        ref: '1.x'
     - name: Build OpenSearch
       working-directory: ./OpenSearch
-      run: ./gradlew publishToMavenLocal -Dbuild.snapshot=false
+      run: ./gradlew publishToMavenLocal -Dopensearch.version=1.1.0-SNAPSHOT
       # Explicitly set the docker-compose program path so that our build scripts in RCA can run the program
       # This is necessary because of the Github Actions environment and the workingDir of the Gradle environment
     - name: Set docker-compose path
@@ -44,7 +44,7 @@ jobs:
       run: sudo sysctl -w vm.max_map_count=262144
     - name: Build PA and run Unit Tests
       working-directory: ./tmp/pa
-      run: ./gradlew build -Dperformance-analyzer-rca.build=true -Dperformance-analyzer-rca.branch=main
+      run: ./gradlew build -Dperformance-analyzer-rca.build=true -Dperformance-analyzer-rca.branch=main -Dopensearch.version=1.1.0-SNAPSHOT
     - name: Generate Jacoco coverage report
       working-directory: ./tmp/pa
       run: ./gradlew jacocoTestReport
@@ -55,4 +55,4 @@ jobs:
       run: bash <(curl -s https://codecov.io/bash) -f ./build/reports/jacoco/test/jacocoTestReport.xml
     - name: Run Integration Tests
       working-directory: ./tmp/pa
-      run: ./gradlew integTest -Dtests.enableIT -Dtests.useDockerCluster
+      run: ./gradlew integTest -Dtests.enableIT -Dtests.useDockerCluster -Dopensearch.version=1.1.0-SNAPSHOT

--- a/build.gradle
+++ b/build.gradle
@@ -346,7 +346,7 @@ task buildRca() {
         exec {
             def licenseDir = "$projectDir/licenses"
             workingDir("$licenseDir")
-            commandLine 'rm', "-f", "performanceanalyzer-rca-${project.version}.jar.sha1"
+            commandLine 'rm', "-f", "performanceanalyzer-rca-${version}.jar.sha1"
         }
     }
 }
@@ -461,7 +461,7 @@ afterEvaluate {
     ospackage {
         packageName = "opensearch-performance-analyzer"
         release = isSnapshot ? "0.1" : '1'
-        version = "${project.version}" - "-SNAPSHOT"
+        version = "${version}" - "-SNAPSHOT"
 
         into '/usr/share/opensearch/plugins'
         from(zipTree(bundlePlugin.archivePath)) {

--- a/build.gradle
+++ b/build.gradle
@@ -27,7 +27,7 @@
 buildscript {
 
     ext {
-        opensearch_version = System.getProperty("opensearch.version", "1.0.0")
+        opensearch_version = System.getProperty("opensearch.version", "1.1.0-SNAPSHOT")
     }
 
     // Used to resolve build file dependencies
@@ -68,7 +68,6 @@ spotbugsTest {
 }
 
 ext {
-    opensearchVersion = '1.0.0'
     isSnapshot = "true" == System.getProperty("build.snapshot", "true")
 
     // The RCA branch that will be built. Default value is main.
@@ -82,7 +81,7 @@ ext {
 }
 
 group = "org.opensearch"
-version = "${opensearchVersion}.0"
+version = opensearch_version - '-SNAPSHOT' + '.0'
 if (isSnapshot) {
     version += "-SNAPSHOT"
 }
@@ -248,7 +247,7 @@ dependencies {
     compile 'org.apache.commons:commons-lang3:3.9'
     compile 'org.bouncycastle:bcprov-jdk15on:1.68'
     compile 'org.bouncycastle:bcpkix-jdk15on:1.68'
-    compile 'org.opensearch:performanceanalyzer-rca:1.0.0.0'
+    compile "org.opensearch:performanceanalyzer-rca:${version}"
     compile "com.fasterxml.jackson.core:jackson-annotations:${jacksonVersion}"
     compile "com.fasterxml.jackson.core:jackson-databind:${jacksonVersion}"
     compile "com.fasterxml.jackson.module:jackson-module-paranamer:${jacksonVersion}"
@@ -331,25 +330,26 @@ task buildRca() {
     dependsOn(cloneGitRepo)
 
     doFirst {
-        logger.info("Building performance-analyzer-rca project in ${rcaProjectDir}")
+        logger.info("Building performance-analyzer-rca project in ${rcaProjectDir} with -Dopensearch.version=${opensearch_version}")
     }
 
     doLast {
         exec {
             workingDir("$rcaProjectDir")
-            commandLine './gradlew', 'build', '-x', 'test'
+            commandLine './gradlew', 'build', '-x', 'test', "-Dopensearch.version=${opensearch_version}"
         }
         exec {
             workingDir("$rcaProjectDir")
-            commandLine './gradlew', 'publishToMavenLocal'
+            commandLine './gradlew', 'publishToMavenLocal', "-Dopensearch.version=${opensearch_version}"
         }
         exec {
             def licenseDir = "$projectDir/licenses"
             workingDir("$licenseDir")
-            commandLine 'rm', "-f", "performanceanalyzer-rca-1.0.0.0.jar.sha1"
+            commandLine 'rm', "-f", "performanceanalyzer-rca-${project.version}.jar.sha1"
         }
     }
 }
+
 buildRca.finalizedBy updateShas
 
 // This value is set by the unpackRca task
@@ -357,7 +357,7 @@ def rcaArtifactsDir
 
 task unpackRca(type: Copy) {
     dependsOn(buildRca)
-    from(zipTree("$rcaProjectDir/build/distributions/performance-analyzer-rca.zip")) {
+    from(zipTree("$rcaProjectDir/build/distributions/performance-analyzer-rca-${version}.zip")) {
     }
     into "$rcaProjectDir/build/distributions"
     rcaArtifactsDir = "$rcaProjectDir/build/distributions/performance-analyzer-rca/"

--- a/build.gradle
+++ b/build.gradle
@@ -70,14 +70,15 @@ spotbugsTest {
 ext {
     isSnapshot = "true" == System.getProperty("build.snapshot", "true")
 
-    // The RCA branch that will be built. Default value is main.
-    rcaProjectBranch = findProperty("performance-analyzer-rca.branch") ?: "main"
+    // The RCA branch that will be built. Default branch is main.
+    rcaProjectRepo = System.getProperty("performance-analyzer-rca.repo", "https://github.com/opensearch-project/performance-analyzer-rca.git")
+    rcaProjectBranch = System.getProperty("performance-analyzer-rca.branch", "main")
 
     // If true, then the build will clone the RCA Project into $rcaProjectDir
     cloneRcaProject = "true" == System.getProperty("performance-analyzer-rca.build", "true")
 
     // By default we will look for RCA in a peer directory
-    rcaProjectDir = findProperty("performance-analyzer-rca.path") ?: "../performance-analyzer-rca"
+    rcaProjectDir = System.getProperty("performance-analyzer-rca.path", "../performance-analyzer-rca")
 }
 
 group = "org.opensearch"
@@ -310,24 +311,24 @@ static def propEnabled(property) {
 // Pass the -Dtests.enableIT property to Gradle to run ITs
 
 /**
- * cloneGitRepo clones the performance-analyzer-rca repo if the -Dtests.enableIT=true flag is passed
+ * cloneRcaGitRepo clones the performance-analyzer-rca repo if the -Dtests.enableIT=true flag is passed
  * to the Gradle JVM
  */
-task cloneGitRepo(type: GitClone) {
+task cloneRcaGitRepo(type: GitClone) {
     def destination = file(rcaProjectDir)
-    uri = "https://github.com/opensearch-project/performance-analyzer-rca.git"
+    uri = rcaProjectRepo
     branch = rcaProjectBranch
     destinationPath = destination
     bare = false
     enabled = cloneRcaProject && !destination.exists() // to clone only once
 
     doFirst {
-        logger.info("Cloning performance-analyzer-rca into ${rcaProjectDir}")
+        logger.info("Cloning performance-analyzer-rca into ${rcaProjectDir} from ${rcaProjectRepo}#${rcaProjectBranch}")
     }
 }
 
 task buildRca() {
-    dependsOn(cloneGitRepo)
+    dependsOn(cloneRcaGitRepo)
 
     doFirst {
         logger.info("Building performance-analyzer-rca project in ${rcaProjectDir} with -Dopensearch.version=${opensearch_version}")
@@ -402,10 +403,10 @@ bundlePlugin {
 
 /**
  * setupOpenSearchCluster spins up a local 2 node OpenSearch cluster using the enableRca task in the performance-analyzer-rca
- * repo. The performance-analyzer-rca repo is cloned as part of the cloneGitRepo task.
+ * repo. The performance-analyzer-rca repo is cloned as part of the cloneRcaGitRepo task.
  */
 task setupOpenSearchCluster() {
-    dependsOn(cloneGitRepo)
+    dependsOn(cloneRcaGitRepo)
     onlyIf = {
         propEnabled("tests.enableIT")
     }


### PR DESCRIPTION
Signed-off-by: dblock <dblock@amazon.com>

**Is your feature request related to a problem? Please provide an existing Issue # , or describe.**

- Fix snapshot build.
- Use OpenSearch 1.1 by default.

There's a circular dependency described in #50, so https://github.com/opensearch-project/performance-analyzer-rca/pull/55 is needed. Once this is merged I'll switch references to my fork that contains this code.

### Check List
- [x] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/performance-analyzer/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
