### PR TITLE
Use performance-analyzer-rca main branch.

### DIFF
--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -44,8 +44,8 @@ jobs:
       working-directory: ./tmp/performance-analyzer
       run: |
         ./gradlew build -Dperformance-analyzer-rca.build=true \
-          -Dperformance-analyzer-rca.repo="https://github.com/dblock/performance-analyzer-rca.git" \
-          -Dperformance-analyzer-rca.branch=fix-snapshot-build \
+          -Dperformance-analyzer-rca.repo="https://github.com/opensearch-project/performance-analyzer-rca.git" \
+          -Dperformance-analyzer-rca.branch=main \
           -Dopensearch.version=1.1.0-SNAPSHOT
     - name: Generate Jacoco coverage report
       working-directory: ./tmp/performance-analyzer


### PR DESCRIPTION
Signed-off-by: dblock <dblock@amazon.com>

Now that https://github.com/opensearch-project/performance-analyzer-rca/pull/55 has been merged, use its main branch.

Together with #53, closes #43.

### Check List
- [x] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/performance-analyzer/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
