### PR TITLE
Fix deleting files within 60sec interval

### DIFF
--- a/src/main/java/org/opensearch/performanceanalyzer/writer/EventLogQueueProcessor.java
+++ b/src/main/java/org/opensearch/performanceanalyzer/writer/EventLogQueueProcessor.java
@@ -192,7 +192,13 @@ public class EventLogQueueProcessor {
             // Delete Event log files belonging to time bucket older than past
             // filesCleanupPeriod(defaults to 60s)
             long currCleanupTimeBucket =
-                    PerformanceAnalyzerMetrics.getTimeInterval(System.currentTimeMillis());
+                    PerformanceAnalyzerMetrics.getTimeInterval(
+                            System.currentTimeMillis() - filesCleanupPeriodicityMillis);
+            // Inorder to prevent calling purging too frequently (where there is no or very less
+            // files),
+            // deletion is called only when range is greater then filesCleanupPeriod (defaults to 60
+            // sec)
+            // This is done to ensure that there is enough files for deletion.
             if (currCleanupTimeBucket - lastCleanupTimeBucket > filesCleanupPeriodicityMillis) {
                 // Get list of files(time buckets) for purging, considered range :
                 // [lastCleanupTimeBucket, currCleanupTimeBucket)


### PR DESCRIPTION
Signed-off-by: Sruti Parthiban <partsrut@amazon.com>

**Is your feature request related to a problem? Please provide an existing Issue # , or describe.**
https://github.com/opensearch-project/performance-analyzer/issues/61

Writer metrics are filling up the disk. Currently, the cleanup method deletes the writer files (https://github.com/opensearch-project/performance-analyzer/blob/main/src/main/java/org/opensearch/performanceanalyzer/writer/EventLogQueueProcessor.java#L190)
This method deletes files up to the current time, but the file creation happens after this. Thus one file is left out during the file deletion. This cause accumulation of writer files.

**Describe the solution you are proposing**
Delete writer files only when they are older than 60sec.

**Additional context**
Add any other context or screenshots about the feature request here.

### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [ ] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/performance-analyzer/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
