### PR TITLE
mv instead of cp performance-analyzer-rca to OS home dir

### DIFF
--- a/packaging/deb/postinst
+++ b/packaging/deb/postinst
@@ -7,7 +7,7 @@ if [ -z "$OPENSEARCH_HOME" ]; then
 fi
 
 # Prepare the RCA reader process for execution
-cp -r "$OPENSEARCH_HOME"/plugins/opensearch-performance-analyzer/performance-analyzer-rca $OPENSEARCH_HOME
+mv "$OPENSEARCH_HOME"/plugins/opensearch-performance-analyzer/performance-analyzer-rca $OPENSEARCH_HOME
 if [ -f "$OPENSEARCH_HOME"/bin/opensearch-performance-analyzer/performance-analyzer-agent-cli ]; then
   mv "$OPENSEARCH_HOME"/bin/opensearch-performance-analyzer/performance-analyzer-agent-cli "$OPENSEARCH_HOME"/bin
   rm -rf "$OPENSEARCH_HOME"/bin/opensearch-performance-analyzer

--- a/packaging/rpm/postinst
+++ b/packaging/rpm/postinst
@@ -13,7 +13,7 @@ if [ -z "$OPENSEARCH_HOME" ]; then
 fi
 
 # Prepare the RCA reader process for execution
-cp -r "$OPENSEARCH_HOME"/plugins/opensearch-performance-analyzer/performance-analyzer-rca $OPENSEARCH_HOME
+mv "$OPENSEARCH_HOME"/plugins/opensearch-performance-analyzer/performance-analyzer-rca $OPENSEARCH_HOME
 if [ -f "$OPENSEARCH_HOME"/bin/opensearch-performance-analyzer/performance-analyzer-agent-cli ]; then
   mv "$OPENSEARCH_HOME"/bin/opensearch-performance-analyzer/performance-analyzer-agent-cli "$OPENSEARCH_HOME"/bin
   rm -rf "$OPENSEARCH_HOME"/bin/opensearch-performance-analyzer


### PR DESCRIPTION
Signed-off-by: Karishma Joseph <karisjos@amazon.com>

**Is your feature request related to a problem? Please provide an existing Issue # , or describe.**
#82 

**Describe the solution you are proposing**
`/plugins/opensearch-performance-analyzer/performance-analyzer-rca/` is not required and used only for copying `performance-analyzer-rca` to OS home dir. Hence, we can move `performance-analyzer-rca` to OS home dir instead of copying it to remove duplicate files.

`plugins/opensearch-performance-analyzer` before moving `performance-analyzer-rca`

```
du -hs plugins/opensearch-performance-analyzer
69M	plugins/opensearch-performance-analyzer
```

`plugins/opensearch-performance-analyzer` after moving `performance-analyzer-rca`

```
du -hs plugins/opensearch-performance-analyzer
34M	plugins/opensearch-performance-analyzer
```

### Check List
- [x] New functionality includes testing.
  - [x] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [x] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/performance-analyzer/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
