### PR TITLE
fix: don't run opensearch-cli in a child process

### DIFF
--- a/packaging/performance-analyzer-agent-cli
+++ b/packaging/performance-analyzer-agent-cli
@@ -7,5 +7,5 @@ PA_AGENT_JAVA_OPTS="-Dlog4j.configurationFile=$OPENSEARCH_HOME/plugins/opensearc
 OPENSEARCH_MAIN_CLASS="org.opensearch.performanceanalyzer.PerformanceAnalyzerApp" \
 OPENSEARCH_ADDITIONAL_CLASSPATH_DIRECTORIES=performance-analyzer-rca/lib \
 OPENSEARCH_JAVA_OPTS=$PA_AGENT_JAVA_OPTS \
- $OPENSEARCH_HOME/bin/opensearch-cli \
+ exec $OPENSEARCH_HOME/bin/opensearch-cli \
    "$@"


### PR DESCRIPTION
The agent CLI starts opensearch-cli in a child process. This has some
nasty drawbacks:

- any signal passed to the agent is not forwarded to opensearch-cli,
  which forces one to kill the process group to actually kill the PA,
- the exit code of the agent is always 0, and the actual exit code of
  opensearch-cli is lost

This commit execs the opensearch-cli command instead of running it in a
subprocess, so that any signal is forwarded to the callee, and any exit
code is forwarded to the caller.

See https://github.com/opensearch-project/opensearch-build/issues/1487