### PR TITLE
Remove PA-RCA files from OS home dir

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -424,8 +424,11 @@ bundlePlugin {
         into "extensions"
         include "performance-analyzer-agent"
     }
-    from("$rcaArtifactsDir") {
-        into "performance-analyzer-rca"
+    from("$rcaArtifactsDir/bin") {
+        into "rca_bin"
+    }
+    from("$rcaArtifactsDir/lib") {
+        into "rca_lib"
     }
     from("packaging") {
         include "performance-analyzer-agent-cli"

--- a/pa_bin/performance-analyzer-agent
+++ b/pa_bin/performance-analyzer-agent
@@ -34,12 +34,12 @@ export JAVA_HOME=$JAVA_HOME
 # We need to change this file: https://github.com/opensearch-project/opensearch-build/blob/main/release/docker/config/opensearch/opensearch-docker-entrypoint.sh
 
 if ! echo $* | grep -E '(^-d |-d$| -d |--daemonize$|--daemonize )' >/dev/null; then
-  export JAVA_OPTS=-Dopensearch.path.home=$OPENSEARCH_HOME\ -Dlog4j.configurationFile=$OPENSEARCH_HOME/performance-analyzer-rca-1.3.0-SNAPSHOT/pa_config/log4j2.xml
-  exec $OPENSEARCH_HOME/performance-analyzer-rca-1.3.0-SNAPSHOT/bin/performance-analyzer-rca
+  export JAVA_OPTS=-Dopensearch.path.home=$OPENSEARCH_HOME\ -Dlog4j.configurationFile=$OPENSEARCH_HOME/plugins/opensearch-performance-analyzer-1.3.0-SNAPSHOT/pa_config/log4j2.xml
+  exec $OPENSEARCH_HOME/plugins/opensearch-performance-analyzer-1.3.0-SNAPSHOT/rca_bin/performance-analyzer-rca
 else
   echo 'Starting deamon'
-  export JAVA_OPTS=-Dopensearch.path.home=$OPENSEARCH_HOME\ -Dlog4j.configurationFile=$OPENSEARCH_HOME/performance-analyzer-rca-1.3.0-SNAPSHOT/pa_config/log4j2.xml
-  exec $OPENSEARCH_HOME/performance-analyzer-rca-1.3.0-SNAPSHOT/bin/performance-analyzer-rca &
+  export JAVA_OPTS=-Dopensearch.path.home=$OPENSEARCH_HOME\ -Dlog4j.configurationFile=$OPENSEARCH_HOME/plugins/opensearch-performance-analyzer-1.3.0-SNAPSHOT/pa_config/log4j2.xml
+  exec $OPENSEARCH_HOME/plugins/opensearch-performance-analyzer-1.3.0-SNAPSHOT/rca_bin/performance-analyzer-rca &
 
   pid=$!
   PID_LOC=/tmp/performance-analyzer-agent

--- a/packaging/deb/postinst
+++ b/packaging/deb/postinst
@@ -7,7 +7,15 @@ if [ -z "$OPENSEARCH_HOME" ]; then
 fi
 
 # Prepare the RCA reader process for execution
-mv "$OPENSEARCH_HOME"/plugins/opensearch-performance-analyzer/performance-analyzer-rca $OPENSEARCH_HOME
+PA_PLUGIN_PATH=$OUTPUT/plugins/opensearch-performance-analyzer
+RCA_LIB_PATH=$OUTPUT/plugins/opensearch-performance-analyzer/rca_lib
+# Remove common lib files between PA plugin and RCA reader process
+for f in `ls -1 $PA_PLUGIN_PATH`; do
+    if [[ $(diff $RCA_LIB_PATH/$f $PA_PLUGIN_PATH/$f | wc -c) -eq 0 ]]; then
+        rm -rf $RCA_LIB_PATH/$f;
+    fi
+done;
+
 if [ -f "$OPENSEARCH_HOME"/bin/opensearch-performance-analyzer/performance-analyzer-agent-cli ]; then
   mv "$OPENSEARCH_HOME"/bin/opensearch-performance-analyzer/performance-analyzer-agent-cli "$OPENSEARCH_HOME"/bin
   rm -rf "$OPENSEARCH_HOME"/bin/opensearch-performance-analyzer
@@ -20,7 +28,6 @@ echo 'true' > /var/lib/opensearch/performance_analyzer_enabled.conf
 echo 'true' > /var/lib/opensearch/rca_enabled.conf
 chown opensearch /var/lib/opensearch/performance_analyzer_enabled.conf
 chown opensearch /var/lib/opensearch/rca_enabled.conf
-chown -R opensearch "$OPENSEARCH_HOME/performance-analyzer-rca"
 chmod a+rw /tmp
 
 if ! grep -q '## OpenSearch Performance Analyzer' /etc/opensearch/jvm.options; then

--- a/packaging/performance-analyzer-agent-cli
+++ b/packaging/performance-analyzer-agent-cli
@@ -5,7 +5,7 @@ PA_AGENT_JAVA_OPTS="-Dlog4j.configurationFile=$OPENSEARCH_HOME/plugins/opensearc
               -XX:MaxRAM=400m"
 
 OPENSEARCH_MAIN_CLASS="org.opensearch.performanceanalyzer.PerformanceAnalyzerApp" \
-OPENSEARCH_ADDITIONAL_CLASSPATH_DIRECTORIES=performance-analyzer-rca/lib \
+OPENSEARCH_ADDITIONAL_CLASSPATH_DIRECTORIES=plugins/opensearch-performance-analyzer/rca_lib:plugins/opensearch-performance-analyzer \
 OPENSEARCH_JAVA_OPTS=$PA_AGENT_JAVA_OPTS \
  exec $OPENSEARCH_HOME/bin/opensearch-cli \
    "$@"

--- a/packaging/rpm/postinst
+++ b/packaging/rpm/postinst
@@ -13,7 +13,15 @@ if [ -z "$OPENSEARCH_HOME" ]; then
 fi
 
 # Prepare the RCA reader process for execution
-mv "$OPENSEARCH_HOME"/plugins/opensearch-performance-analyzer/performance-analyzer-rca $OPENSEARCH_HOME
+PA_PLUGIN_PATH=$OUTPUT/plugins/opensearch-performance-analyzer
+RCA_LIB_PATH=$OUTPUT/plugins/opensearch-performance-analyzer/rca_lib
+# Remove common lib files between PA plugin and RCA reader process
+for f in `ls -1 $PA_PLUGIN_PATH`; do
+    if [[ $(diff $RCA_LIB_PATH/$f $PA_PLUGIN_PATH/$f | wc -c) -eq 0 ]]; then
+        rm -rf $RCA_LIB_PATH/$f;
+    fi
+done;
+
 if [ -f "$OPENSEARCH_HOME"/bin/opensearch-performance-analyzer/performance-analyzer-agent-cli ]; then
   mv "$OPENSEARCH_HOME"/bin/opensearch-performance-analyzer/performance-analyzer-agent-cli "$OPENSEARCH_HOME"/bin
   rm -rf "$OPENSEARCH_HOME"/bin/opensearch-performance-analyzer
@@ -26,7 +34,6 @@ echo 'true' > /var/lib/opensearch/performance_analyzer_enabled.conf
 echo 'true' > /var/lib/opensearch/rca_enabled.conf
 chown opensearch /var/lib/opensearch/performance_analyzer_enabled.conf
 chown opensearch /var/lib/opensearch/rca_enabled.conf
-chown -R opensearch "$OPENSEARCH_HOME/performance-analyzer-rca"
 chmod a+rw /tmp
 
 if ! grep -q '## OpenSearch Performance Analyzer' /etc/opensearch/jvm.options; then


### PR DESCRIPTION
Signed-off-by: Karishma Joseph <karisjos@amazon.com>

[Merge only when PA is stable]

**Is your feature request related to a problem? Please provide an existing Issue # , or describe.**
#82 

**Describe the solution you are proposing**
Remove the`<OS_HOME>/performance-analyzer-rca` folder from the OS home directory. This way there is only one location for PA plugin and PA-RCA process: `<OS_HOME>/plugins/opensearch-performance-analyzer`. 

Contents of `<OS_HOME>/performance-analyzer-rca` before:
```
bin  lib  pa_bin  pa_config
```


`pa_bin` and `pa_config` in `<OS_HOME>/performance-analyzer-rca` and `<OS_HOME>/plugins/opensearch-performance-analyzer` were exactly the same. Hence, no action needs to be taken for these two folders.

Copy `bin` into `<OS_HOME>/plugins/opensearch-performance-analyzer` and rename as `rca_bin`.

Copy `lib` into `<OS_HOME>/plugins/opensearch-performance-analyzer` and rename as `rca_lib`. Remove all the common library files between `<OS_HOME>/plugins/opensearch-performance-analyzer` and `<OS_HOME>/plugins/opensearch-performance-analyzer/rca_lib` so as to reduce the memory footprint.


### Check List
- [x] New functionality includes testing.
  - [x] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [x] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/performance-analyzer/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
