### PR TITLE
Add auto backport functionality, backport delete, and documentation

### DIFF
--- a/.github/workflows/backport.yml
+++ b/.github/workflows/backport.yml
@@ -1,0 +1,28 @@
+name: Backport
+on:
+  pull_request_target:
+    types:
+      - closed
+      - labeled
+
+jobs:
+  backport:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
+    name: Backport
+    steps:
+      - name: GitHub App token
+        id: github_app_token
+        uses: tibdex/github-app-token@v1.5.0
+        with:
+          app_id: ${{ secrets.APP_ID }}
+          private_key: ${{ secrets.APP_PRIVATE_KEY }}
+          installation_id: 22958780
+
+      - name: Backport
+        uses: VachaShah/backport@v1.1.4
+        with:
+          github_token: ${{ steps.github_app_token.outputs.token }}
+          branch_name: backport/backport-${{ github.event.number }}

--- a/.github/workflows/delete_backport_branch.yml
+++ b/.github/workflows/delete_backport_branch.yml
@@ -1,0 +1,15 @@
+name: Delete merged branch of the backport PRs
+on:
+  pull_request:
+    types:
+      - closed
+
+jobs:
+  delete-branch:
+    runs-on: ubuntu-latest
+    if: startsWith(github.event.pull_request.head.ref,'backport/')
+    steps:
+      - name: Delete merged branch
+        uses: SvanBoxel/delete-merged-branch@main
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/DEVELOPER_GUIDE.md
+++ b/DEVELOPER_GUIDE.md
@@ -43,3 +43,11 @@ Launch Intellij IDEA, choose **Import Project**, and select the `build.gradle` f
 ### Submitting Changes
 
 See [CONTRIBUTING](CONTRIBUTING.md).
+
+### Backports
+
+The Github workflow in [`backport.yml`](.github/workflows/backport.yml) creates backport PRs automatically when the
+original PR with an appropriate label `backport <backport-branch-name>` is merged to main with the backport workflow
+run successfully on the PR. For example, if a PR on main needs to be backported to `1.x` branch, add a label
+`backport 1.x` to the PR and make sure the backport workflow runs on the PR along with other checks. Once this PR is
+merged to main, the workflow will create a backport PR to the `1.x` branch.


### PR DESCRIPTION
Signed-off-by: David Zane <davizane@amazon.com>

### Description
Adds backport workflow to allow automatic backport PR creation as we merge to main or label PR. Explanation of script added to documentation.

#### Side Notes:
* We can label previously closed PRs and the action will run.

### Issues Resolved
resolves https://github.com/opensearch-project/performance-analyzer/issues/93

### Check List
- [x] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/performance-analyzer/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
