### PR TITLE
Adding check to avoid adding module export for jdk8

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -117,7 +117,10 @@ compileJava {
 }
 
 javadoc {
-    options.addStringOption("-add-exports", "jdk.attach/sun.tools.attach=ALL-UNNAMED")
+    JavaVersion targetVersion = JavaVersion.toVersion(targetCompatibility);
+    if (targetVersion.isJava9Compatible()) {
+        options.addStringOption("-add-exports", "jdk.attach/sun.tools.attach=ALL-UNNAMED")
+    }
 }
 
 project.afterEvaluate {


### PR DESCRIPTION
Signed-off-by: Sagar Upadhyaya <upasagar@amazon.com>

**Is your feature request related to a problem? Please provide an existing Issue # , or describe.**
While building PA along with RCA and running unit tests https://github.com/opensearch-project/performance-analyzer-rca/pull/145 for jdk8, workflow step failed as we have a logic currently in build.gradle to export a module which is not supported for versions <=8.

**Describe the solution you are proposing**
Adding the desired check.

**Describe alternatives you've considered**
A clear and concise description of any alternative solutions or features you've considered.

**Additional context**
Add any other context or screenshots about the feature request here.

### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [ ] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/performance-analyzer/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
