### PR TITLE
Disabling dependency license check for now in gradle to unblock jdk8 …

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -311,6 +311,7 @@ dependencies {
 }
 
 dependencyLicenses {
+    enabled false
     mapping from: /jackson-.*/, to: 'jackson'
 }
 


### PR DESCRIPTION
…build

Signed-off-by: Sagar Upadhyaya <upasagar@amazon.com>

**Is your feature request related to a problem? Please provide an existing Issue # , or describe.**
Disabling dependency license check to unblock jdk8 build for now. Was failing due to missing tools.jar license.
Doing similar as index-management plugin - https://github.com/opensearch-project/index-management/blob/main/build.gradle#L184

**Describe the solution you are proposing**
A clear and concise description of what you want to happen.

**Describe alternatives you've considered**
A clear and concise description of any alternative solutions or features you've considered.

**Additional context**
Add any other context or screenshots about the feature request here.

### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [ ] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/performance-analyzer/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
