### PR TITLE
Replace Forum link in Performance Analyzer plugin README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 [![CD](https://github.com/opensearch-project/performance-analyzer/workflows/CD/badge.svg)](https://github.com/opensearch-project/performance-analyzer/actions?query=workflow%3ACD)
 [![codecov](https://codecov.io/gh/opensearch-project/performance-analyzer/branch/main/graph/badge.svg)](https://codecov.io/gh/opensearch-project/performance-analyzer)
 [![Documentation](https://img.shields.io/badge/api-reference-blue.svg)](https://opensearch.org/docs/monitoring-plugins/pa/api/)
-[![Chat](https://img.shields.io/badge/chat-on%20forums-blue)](https://discuss.opendistrocommunity.dev/c/performance-analyzer/)
+[![Chat](https://img.shields.io/badge/chat-on%20forums-blue)](https://forum.opensearch.org/c/plugins/performance-analyzer/9)
 ![PRs welcome!](https://img.shields.io/badge/PRs-welcome!-success)
 
 <img src="https://opensearch.org/assets/img/opensearch-logo-themed.svg" height="64px">


### PR DESCRIPTION
Signed-off-by: cwillum <cwmmoore@amazon.com>

**Is your feature request related to a problem?**
This fixes the issue for the Performance Analyzer plugin in [#921](https://github.com/opensearch-project/documentation-website/issues/921).

**Describe the solution you are proposing**
Replaced the link to the Forum discussion in the README.md file so that it points to the OpenSearch forum rather than the defunct Open Distro forum.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/performance-analyzer/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
