### PR TITLE
Remove duplicate reference to rcaProjectFetch

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -66,7 +66,7 @@ ext {
     // The RCA branch that will be built. Default branch is main.
     rcaProjectRepo = System.getProperty("performance-analyzer-rca.repo", "https://github.com/opensearch-project/performance-analyzer-rca.git")
     rcaProjectFetch = System.getProperty("performance-analyzer-rca.fetch", "origin")
-    rcaProjectBranch = System.getProperty("performance-analyzer-rca.branch", "${rcaProjectFetch}/main")
+    rcaProjectBranch = System.getProperty("performance-analyzer-rca.branch", "main")
 
     // If true, then the build will clone the RCA Project into $rcaProjectDir
     cloneRcaProject = "true" == System.getProperty("performance-analyzer-rca.build", "true")


### PR DESCRIPTION
Signed-off-by: Craig Perkins <cwperx@amazon.com>

**Is your feature request related to a problem? Please provide an existing Issue # , or describe.**

2.4.0 Distribution build is failing. See issue here: https://github.com/opensearch-project/performance-analyzer/issues/282

The build fails with the following output:

```
> Task :cloneRcaGitRepo
Cloning performance-analyzer-rca into ../performance-analyzer-rca from https://github.com/opensearch-project/performance-analyzer-rca.git#origin/2.x

> Task :cloneRcaGitRepo FAILED

FAILURE: Build failed with an exception.

* Where:
Build file '/tmp/tmpgdrnaj03/performance-analyzer/build.gradle' line: 395

* What went wrong:
Execution failed for task ':cloneRcaGitRepo'.
> org.eclipse.jgit.api.errors.RefNotFoundException: Ref origin/origin/2.x cannot be resolved
```

Latest build output can be found here: https://build.ci.opensearch.org/job/distribution-build-opensearch/6082/console

### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [ ] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/performance-analyzer/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
