### PR TITLE
Adding connection read timeout to prevent indefinite wait

### DIFF
--- a/src/main/java/org/opensearch/performanceanalyzer/http_action/config/PerformanceAnalyzerResourceProvider.java
+++ b/src/main/java/org/opensearch/performanceanalyzer/http_action/config/PerformanceAnalyzerResourceProvider.java
@@ -44,6 +44,7 @@ public class PerformanceAnalyzerResourceProvider extends BaseRestHandler {
             LogManager.getLogger(PerformanceAnalyzerResourceProvider.class);
 
     private static final int HTTP_CLIENT_CONNECTION_TIMEOUT_MILLIS = 200;
+    private static final int HTTP_READ_CONNECTON_TIMEOUT_MILLIS = 10000;
     private static final String AGENT_PATH = RestConfig.PA_BASE_URI + "/_agent/";
     private static final String LEGACY_AGENT_PATH = RestConfig.LEGACY_PA_BASE_URI + "/_agent/";
     private static final String DEFAULT_PORT_NUMBER = "9600";
@@ -202,12 +203,14 @@ public class PerformanceAnalyzerResourceProvider extends BaseRestHandler {
     private HttpURLConnection createHttpsURLConnection(URL url) throws IOException {
         HttpsURLConnection httpsURLConnection = (HttpsURLConnection) url.openConnection();
         httpsURLConnection.setConnectTimeout(HTTP_CLIENT_CONNECTION_TIMEOUT_MILLIS);
+        httpsURLConnection.setReadTimeout(HTTP_READ_CONNECTON_TIMEOUT_MILLIS);
         return httpsURLConnection;
     }
 
     private HttpURLConnection createHttpURLConnection(URL url) throws IOException {
         HttpURLConnection httpURLConnection = (HttpURLConnection) url.openConnection();
         httpURLConnection.setConnectTimeout(HTTP_CLIENT_CONNECTION_TIMEOUT_MILLIS);
+        httpURLConnection.setReadTimeout(HTTP_READ_CONNECTON_TIMEOUT_MILLIS);
         return httpURLConnection;
     }
 


### PR DESCRIPTION
Signed-off-by: Sagar Upadhyaya <sagar.upadhyaya.121@gmail.com>

**Is your feature request related to a problem? Please provide an existing Issue # , or describe.**
We saw an issue where threads were stuck indefinitely while waiting for metric response. This happened as PA plugin creates connection and request metrics from PA agent on port 9600. PA agent somehow resulted in exception and didn't send the response back making PA wait forever.

**Repro**
Threw exception in RCA deliberately [here](https://github.com/opensearch-project/performance-analyzer-rca/blob/main/src/main/java/org/opensearch/performanceanalyzer/rest/QueryMetricsRequestHandler.java#L315-L316).
By issuing command like ```GET /_performanceanalyzer/_agent/metrics``` on 9200, it got stuck. And issuing multiple such caused opensearch process to be stuck.

**Describe the solution you are proposing**
Adding read timeout of 10sec for now.

**Describe alternatives you've considered**
Avoid blocking IO and use non blocking here in future.

**Additional context**
When thread dump was taken, we saw many traces(>200) like below:
```
java.lang.Thread.State: RUNNABLE
        at java.net.SocketInputStream.socketRead0(java.base@11.0.16/Native Method)
        at java.net.SocketInputStream.socketRead(java.base@11.0.16/SocketInputStream.java:115)
        at java.net.SocketInputStream.read(java.base@11.0.16/SocketInputStream.java:168)
        at java.net.SocketInputStream.read(java.base@11.0.16/SocketInputStream.java:140)
        at java.io.BufferedInputStream.fill(java.base@11.0.16/BufferedInputStream.java:252)
        at java.io.BufferedInputStream.read1(java.base@11.0.16/BufferedInputStream.java:292)
        at java.io.BufferedInputStream.read(java.base@11.0.16/BufferedInputStream.java:351)
        - locked <0x0000000469369e70> (a java.io.BufferedInputStream)
        at sun.net.www.MeteredStream.read(java.base@11.0.16/MeteredStream.java:134)
```

**Testing**
Tested by spinning up a OS 1.x cluster and threw deliberate exception from RCA [here](https://github.com/opensearch-project/performance-analyzer-rca/blob/main/src/main/java/org/opensearch/performanceanalyzer/rest/QueryMetricsRequestHandler.java#L315-L316) so that it gets stuck. With this timeout change it resulted into exception after 10sec.
```
{"error":{"root_cause":[{"type":"socket_timeout_exception","reason":"Read timed out"}],"type":"socket_timeout_exception","reason":"Read timed out"},"status":500}
```

### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [ ] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/performance-analyzer/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
