### PR TITLE
Cluster config api return verbose PA status (#342)

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,6 +68,10 @@ GET localhost:9200/_plugins/_performanceanalyzer/config
 GET localhost:9200/_plugins/_performanceanalyzer/cluster/config
 
 {"currentPerformanceAnalyzerClusterState":9,"shardsPerCollection":0,"batchMetricsRetentionPeriodMinutes":7}
+
+GET localhost:9200/_plugins/_performanceanalyzer/cluster/config?verbose
+
+{"currentPerformanceAnalyzerClusterState":{"PerformanceAnalyzerEnabled":false,"RcaEnabled":false,"LoggingEnabled":false,"BatchMetricsEnabled":false},"shardsPerCollection":0,"batchMetricsRetentionPeriodMinutes":7
 ```
 
 The default retention period is 7 minutes. However, the cluster owner can adjust this by setting `batch-metrics-retention-period-minutes` in performance-analyzer.properties (note, setting this value will require a restart so that the cluster can read the new value upon startup). The value must be between 1 and 60 minutes (inclusive) — the range is capped like so in order to prevent excessive data retention on the cluster, which would eat up a lot of storage.

--- a/src/main/java/org/opensearch/performanceanalyzer/config/setting/handler/PerformanceAnalyzerClusterSettingHandler.java
+++ b/src/main/java/org/opensearch/performanceanalyzer/config/setting/handler/PerformanceAnalyzerClusterSettingHandler.java
@@ -27,6 +27,8 @@
 package org.opensearch.performanceanalyzer.config.setting.handler;
 
 
+import java.util.LinkedHashMap;
+import java.util.Map;
 import org.opensearch.performanceanalyzer.config.PerformanceAnalyzerController;
 import org.opensearch.performanceanalyzer.config.setting.ClusterSettingListener;
 import org.opensearch.performanceanalyzer.config.setting.ClusterSettingsManager;
@@ -50,6 +52,11 @@ public class PerformanceAnalyzerClusterSettingHandler implements ClusterSettingL
     private static final int BATCH_METRICS_ENABLED_BIT_POS =
             PerformanceAnalyzerClusterSettings.PerformanceAnalyzerFeatureBits.BATCH_METRICS_BIT
                     .ordinal();
+
+    static final String PA_ENABLED_KEY = "PerformanceAnalyzerEnabled";
+    static final String RCA_ENABLED_KEY = "RcaEnabled";
+    static final String LOGGING_ENABLED_KEY = "LoggingEnabled";
+    static final String BATCH_METRICS_ENABLED_KEY = "BatchMetricsEnabled";
 
     private final PerformanceAnalyzerController controller;
     private final ClusterSettingsManager clusterSettingsManager;
@@ -137,6 +144,19 @@ public class PerformanceAnalyzerClusterSettingHandler implements ClusterSettingL
      */
     public int getCurrentClusterSettingValue() {
         return currentClusterSetting;
+    }
+
+    public Map<String, Boolean> getCurrentClusterSettingValueVerbose() {
+        Map<String, Boolean> statusMap = new LinkedHashMap<String, Boolean>();
+        statusMap.put(PA_ENABLED_KEY, getPAStateFromSetting(currentClusterSetting.intValue()));
+        statusMap.put(RCA_ENABLED_KEY, getRcaStateFromSetting(currentClusterSetting.intValue()));
+        statusMap.put(
+                LOGGING_ENABLED_KEY, getLoggingStateFromSetting(currentClusterSetting.intValue()));
+        statusMap.put(
+                BATCH_METRICS_ENABLED_KEY,
+                getBatchMetricsStateFromSetting(currentClusterSetting.intValue()));
+
+        return statusMap;
     }
 
     /**

--- a/src/main/java/org/opensearch/performanceanalyzer/http_action/config/PerformanceAnalyzerClusterConfigAction.java
+++ b/src/main/java/org/opensearch/performanceanalyzer/http_action/config/PerformanceAnalyzerClusterConfigAction.java
@@ -171,6 +171,7 @@ public class PerformanceAnalyzerClusterConfigAction extends BaseRestHandler {
     @Override
     protected RestChannelConsumer prepareRequest(final RestRequest request, final NodeClient client)
             throws IOException {
+        request.param("verbose");
         if (request.method() == RestRequest.Method.POST && request.content().length() > 0) {
             Map<String, Object> map =
                     XContentHelper.convertToMap(request.content(), false, XContentType.JSON).v2();
@@ -208,7 +209,11 @@ public class PerformanceAnalyzerClusterConfigAction extends BaseRestHandler {
             try {
                 XContentBuilder builder = channel.newBuilder();
                 builder.startObject();
-                builder.field(CURRENT, clusterSettingHandler.getCurrentClusterSettingValue());
+                builder.field(
+                        CURRENT,
+                        request.paramAsBoolean("verbose", false)
+                                ? clusterSettingHandler.getCurrentClusterSettingValueVerbose()
+                                : clusterSettingHandler.getCurrentClusterSettingValue());
                 builder.field(SHARDS_PER_COLLECTION, nodeStatsSettingHandler.getNodeStatsSetting());
                 builder.field(
                         BATCH_METRICS_RETENTION_PERIOD_MINUTES,

--- a/src/test/java/org/opensearch/performanceanalyzer/config/setting/handler/PerformanceAnalyzerClusterSettingHandlerTests.java
+++ b/src/test/java/org/opensearch/performanceanalyzer/config/setting/handler/PerformanceAnalyzerClusterSettingHandlerTests.java
@@ -30,6 +30,8 @@ import static org.junit.Assert.assertEquals;
 import static org.mockito.MockitoAnnotations.initMocks;
 import static org.powermock.api.mockito.PowerMockito.when;
 
+import java.util.LinkedHashMap;
+import java.util.Map;
 import org.junit.Before;
 import org.junit.Test;
 import org.mockito.Mock;
@@ -39,6 +41,16 @@ import org.opensearch.performanceanalyzer.config.setting.ClusterSettingsManager;
 public class PerformanceAnalyzerClusterSettingHandlerTests {
     private static final Boolean DISABLED_STATE = Boolean.FALSE;
     private static final Boolean ENABLED_STATE = Boolean.TRUE;
+
+    private final Map<String, Boolean> ALL_ENABLED_CLUSTER =
+            createStatusMap(
+                    ENABLED_STATE, ENABLED_STATE, ENABLED_STATE, ENABLED_STATE);
+    private final Map<String, Boolean> ALL_DISABLED_CLUSTER =
+            createStatusMap(
+                    DISABLED_STATE, DISABLED_STATE, DISABLED_STATE, DISABLED_STATE);
+    private final Map<String, Boolean> MIXED_STATUS_CLUSTER =
+            createStatusMap(
+                    ENABLED_STATE, ENABLED_STATE, DISABLED_STATE, DISABLED_STATE);
 
     private PerformanceAnalyzerClusterSettingHandler clusterSettingHandler;
 
@@ -57,6 +69,8 @@ public class PerformanceAnalyzerClusterSettingHandlerTests {
                 new PerformanceAnalyzerClusterSettingHandler(
                         mockPerformanceAnalyzerController, mockClusterSettingsManager);
         assertEquals(0, clusterSettingHandler.getCurrentClusterSettingValue());
+        assertEquals(
+                ALL_DISABLED_CLUSTER, clusterSettingHandler.getCurrentClusterSettingValueVerbose());
     }
 
     @Test
@@ -66,6 +80,8 @@ public class PerformanceAnalyzerClusterSettingHandlerTests {
                 new PerformanceAnalyzerClusterSettingHandler(
                         mockPerformanceAnalyzerController, mockClusterSettingsManager);
         assertEquals(15, clusterSettingHandler.getCurrentClusterSettingValue());
+        assertEquals(
+                ALL_ENABLED_CLUSTER, clusterSettingHandler.getCurrentClusterSettingValueVerbose());
     }
 
     @Test
@@ -75,6 +91,8 @@ public class PerformanceAnalyzerClusterSettingHandlerTests {
                 new PerformanceAnalyzerClusterSettingHandler(
                         mockPerformanceAnalyzerController, mockClusterSettingsManager);
         assertEquals(0, clusterSettingHandler.getCurrentClusterSettingValue());
+        assertEquals(
+                ALL_DISABLED_CLUSTER, clusterSettingHandler.getCurrentClusterSettingValueVerbose());
     }
 
     @Test
@@ -84,8 +102,12 @@ public class PerformanceAnalyzerClusterSettingHandlerTests {
                 new PerformanceAnalyzerClusterSettingHandler(
                         mockPerformanceAnalyzerController, mockClusterSettingsManager);
         assertEquals(3, clusterSettingHandler.getCurrentClusterSettingValue());
+        assertEquals(
+                MIXED_STATUS_CLUSTER, clusterSettingHandler.getCurrentClusterSettingValueVerbose());
         clusterSettingHandler.onSettingUpdate(0);
         assertEquals(0, clusterSettingHandler.getCurrentClusterSettingValue());
+        assertEquals(
+                ALL_DISABLED_CLUSTER, clusterSettingHandler.getCurrentClusterSettingValueVerbose());
     }
 
     private void setControllerValues(
@@ -99,5 +121,20 @@ public class PerformanceAnalyzerClusterSettingHandlerTests {
         when(mockPerformanceAnalyzerController.isLoggingEnabled()).thenReturn(loggingEnabled);
         when(mockPerformanceAnalyzerController.isBatchMetricsEnabled())
                 .thenReturn(batchMetricsEnabled);
+    }
+
+    private Map<String, Boolean> createStatusMap(
+            final Boolean paEnabled,
+            final Boolean rcaEnabled,
+            final Boolean loggingEnabled,
+            final Boolean batchMetricsEnabled {
+        Map<String, Boolean> statusMap = new LinkedHashMap<String, Boolean>();
+        statusMap.put(PerformanceAnalyzerClusterSettingHandler.PA_ENABLED_KEY, paEnabled);
+        statusMap.put(PerformanceAnalyzerClusterSettingHandler.RCA_ENABLED_KEY, rcaEnabled);
+        statusMap.put(PerformanceAnalyzerClusterSettingHandler.LOGGING_ENABLED_KEY, loggingEnabled);
+        statusMap.put(
+                PerformanceAnalyzerClusterSettingHandler.BATCH_METRICS_ENABLED_KEY,
+                batchMetricsEnabled);
+        return statusMap;
     }
 }


### PR DESCRIPTION
* Cluster config api return verbose PA status

Signed-off-by: David Zane <davizane@amazon.com>
(cherry picked from commit 1f35eebbc9b25d46eb2b81463be7e2ba4e7bfc91)

**Is your feature request related to a problem? Please provide an existing Issue # , or describe.**
A clear and concise description of what the problem is. Ex. I'm always frustrated when [...]

**Describe the solution you are proposing**
A clear and concise description of what you want to happen.

**Describe alternatives you've considered**
A clear and concise description of any alternative solutions or features you've considered.

**Additional context**
Add any other context or screenshots about the feature request here.

### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [ ] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/performance-analyzer/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
