### PR TITLE
Fix AdmissionControl class loading issue in Netty/PA communication

### DIFF
--- a/src/main/java/org/opensearch/performanceanalyzer/collectors/AdmissionControlMetricsCollector.java
+++ b/src/main/java/org/opensearch/performanceanalyzer/collectors/AdmissionControlMetricsCollector.java
@@ -40,9 +40,12 @@ public class AdmissionControlMetricsCollector extends PerformanceAnalyzerMetrics
     private static final String ADMISSION_CONTROL_SERVICE =
             "com.sonian.opensearch.http.jetty.throttling.JettyAdmissionControlService";
 
+    private final ClassLoader admissionControlClassLoaer;
+
     public AdmissionControlMetricsCollector() {
         super(sTimeInterval, "AdmissionControlMetricsCollector");
         this.value = new StringBuilder();
+        this.admissionControlClassLoaer = this.getClass().getClassLoader().getParent();
     }
 
     @Override
@@ -57,8 +60,11 @@ public class AdmissionControlMetricsCollector extends PerformanceAnalyzerMetrics
 
         long startTimeMillis = System.currentTimeMillis();
         try {
-            Class admissionController = Class.forName(ADMISSION_CONTROLLER);
-            Class jettyAdmissionControlService = Class.forName(ADMISSION_CONTROL_SERVICE);
+            Class admissionController =
+                    Class.forName(ADMISSION_CONTROLLER, false, this.admissionControlClassLoaer);
+            Class jettyAdmissionControlService =
+                    Class.forName(
+                            ADMISSION_CONTROL_SERVICE, false, this.admissionControlClassLoaer);
 
             Method getAdmissionController =
                     jettyAdmissionControlService.getDeclaredMethod(
@@ -172,8 +178,8 @@ public class AdmissionControlMetricsCollector extends PerformanceAnalyzerMetrics
 
     private boolean isAdmissionControlFeatureAvailable() {
         try {
-            Class.forName(ADMISSION_CONTROLLER);
-            Class.forName(ADMISSION_CONTROL_SERVICE);
+            Class.forName(ADMISSION_CONTROLLER, false, this.admissionControlClassLoaer);
+            Class.forName(ADMISSION_CONTROL_SERVICE, false, this.admissionControlClassLoaer);
         } catch (ClassNotFoundException e) {
             return false;
         }

--- a/src/main/java/org/opensearch/performanceanalyzer/collectors/AdmissionControlMetricsCollector.java
+++ b/src/main/java/org/opensearch/performanceanalyzer/collectors/AdmissionControlMetricsCollector.java
@@ -48,7 +48,7 @@ public class AdmissionControlMetricsCollector extends PerformanceAnalyzerMetrics
     public AdmissionControlMetricsCollector() {
         super(sTimeInterval, "AdmissionControlMetricsCollector");
         this.value = new StringBuilder();
-        this.admissionControllerAvailable = canLoadAdmissionContollerClasses();
+        this.admissionControllerAvailable = canLoadAdmissionControllerClasses();
     }
 
     @Override
@@ -174,7 +174,7 @@ public class AdmissionControlMetricsCollector extends PerformanceAnalyzerMetrics
         }
     }
 
-    private boolean canLoadAdmissionContollerClasses() {
+    private boolean canLoadAdmissionControllerClasses() {
         try {
             ClassLoader admissionControlClassLoader = this.getClass().getClassLoader().getParent();
             this.admissionControllerClass =


### PR DESCRIPTION
**Is your feature request related to a problem? Please provide an existing Issue # , or describe.**
PA AdmissionControl colector is taking dependency on AOS's AdmissionControl plugin to retrieve JVMMP & Request_Size 
 quota related metrics. PA uses reflection to retrieve static insances of AdmissionControllers. 
 Unit now it worked fine since, Jetty plugin was in /lib diretory and was getting loaded by same classloader. But now that AOS is moving to Netty, Netty is completely seperate plugin and no in /lib folder. Hence PA & Netty plugins shares different classloaders. However, there is a way we can still load AdmissionControl classes with parent ClassLoaders. PluginService when loads extended plugins, it passes parent classloader for all extended plugins. [Ref](https://github.com/opensearch-project/OpenSearch/blob/main/server/src/main/java/org/opensearch/plugins/PluginsService.java#L702)
We will have to add a line, in opensearch-performance-analyzer plugin. So that PluginService passes AdmissionControl class loader to PA.

**Describe alternatives you've considered**
The cleanest way to implement this would be to provide an SPI from PA and AdmissionControl will use this SPI to implement controllers. In that way, PA will be `[ExtensiblePlugin](https://github.com/opensearch-project/OpenSearch/blob/main/server/src/main/java/org/opensearch/plugins/ExtensiblePlugin.java)` and AdmissionControl plugin will extend PA plugin, I tried doing that and it resulted in lot of complications, like jar hell, dependencies version conflicts etc. Also this approach will clash with Jetty as now we will have tow different solutions for Netty/Jetty. We can still handle all those scenarios, but I would suggest to keep that task on our backlog (including making AdmissionControl plugin opensource).

**Additional context**
Add any other context or screenshots about the feature request here.

### Check List
- [x] New functionality includes testing.
  - [x] All tests pass
- [x] New functionality has been documented.
  - [x] New functionality has javadoc added
- [x] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/performance-analyzer/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
