### PR TITLE
Adding getClassLoader permission to plugin-security policy for AD Netty Change

### DIFF
--- a/src/main/resources/plugin-security.policy
+++ b/src/main/resources/plugin-security.policy
@@ -18,8 +18,11 @@ grant {
   permission java.lang.RuntimePermission "loadLibrary.attach";
   permission java.lang.RuntimePermission "accessClassInPackage.jdk.internal.misc";
   permission java.lang.RuntimePermission "accessClassInPackage.sun.tools.attach";
+
+  // needed to find the classloader to load AD classes
   permission java.lang.RuntimePermission "createClassLoader";
   permission java.lang.RuntimePermission "defineClass";
+  permission java.lang.RuntimePermission "getClassLoader";
 
 };
 


### PR DESCRIPTION
**Is your feature request related to a problem? Please provide an existing Issue # , or describe.**
A recent change [Fix AdmissionControl class loading issue in Netty/PA communication](https://github.com/opensearch-project/performance-analyzer/pull/402) did not add the required permissions to the plugin-security policy, leading to failures in loading the plugin during cluster bootstrap.

Errors from https://github.com/khushbr/performance-analyzer/actions/runs/4557280122/jobs/8038690384: 
```
Caused by: java.security.AccessControlException: access denied ("java.lang.RuntimePermission" "getClassLoader")
»  	at java.security.AccessControlContext.checkPermission(AccessControlContext.java:472) ~[?:?]
»  	at java.security.AccessController.checkPermission(AccessController.java:897) ~[?:?]
»  	at java.lang.SecurityManager.checkPermission(SecurityManager.java:322) ~[?:?]
»  	at java.lang.ClassLoader.checkClassLoaderPermission(ClassLoader.java:2060) ~[?:?]
»  	at java.lang.ClassLoader.getParent(ClassLoader.java:1806) ~[?:?]
»  	at org.opensearch.performanceanalyzer.collectors.AdmissionControlMetricsCollector.canLoadAdmissionControllerClasses(AdmissionControlMetricsCollector.java:179) ~[?:?]
```

### Check List
- [y ] New functionality includes testing.
  - [ y] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [ y] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/performance-analyzer/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
