### PR TITLE
Revert "Fix AdmissionControl class loading issue in Netty/PA communication (#402)"

### DIFF
--- a/src/main/java/org/opensearch/performanceanalyzer/collectors/AdmissionControlMetricsCollector.java
+++ b/src/main/java/org/opensearch/performanceanalyzer/collectors/AdmissionControlMetricsCollector.java
@@ -40,21 +40,15 @@ public class AdmissionControlMetricsCollector extends PerformanceAnalyzerMetrics
     private static final String ADMISSION_CONTROL_SERVICE =
             "com.sonian.opensearch.http.jetty.throttling.JettyAdmissionControlService";
 
-    private Class admissionControllerClass;
-    private Class jettyAdmissionControllerServiceClass;
-    private final boolean admissionControllerAvailable;
-
-
     public AdmissionControlMetricsCollector() {
         super(sTimeInterval, "AdmissionControlMetricsCollector");
         this.value = new StringBuilder();
-        this.admissionControllerAvailable = canLoadAdmissionControllerClasses();
     }
 
     @Override
     @SuppressWarnings("unchecked")
     public void collectMetrics(long startTime) {
-        if (!this.admissionControllerAvailable) {
+        if (!isAdmissionControlFeatureAvailable()) {
             LOG.debug("AdmissionControl is not available for this domain");
             PerformanceAnalyzerApp.WRITER_METRICS_AGGREGATOR.updateStat(
                     WriterMetrics.ADMISSION_CONTROL_COLLECTOR_NOT_AVAILABLE, "", 1);
@@ -63,9 +57,11 @@ public class AdmissionControlMetricsCollector extends PerformanceAnalyzerMetrics
 
         long startTimeMillis = System.currentTimeMillis();
         try {
+            Class admissionController = Class.forName(ADMISSION_CONTROLLER);
+            Class jettyAdmissionControlService = Class.forName(ADMISSION_CONTROL_SERVICE);
 
             Method getAdmissionController =
-                    this.jettyAdmissionControllerServiceClass.getDeclaredMethod(
+                    jettyAdmissionControlService.getDeclaredMethod(
                             "getAdmissionController", String.class);
 
             Object globalJVMMP = getAdmissionController.invoke(null, GLOBAL_JVMMP);
@@ -77,9 +73,9 @@ public class AdmissionControlMetricsCollector extends PerformanceAnalyzerMetrics
 
             value.setLength(0);
 
-            Method getUsedQuota = this.admissionControllerClass.getDeclaredMethod("getUsedQuota");
-            Method getTotalQuota = this.admissionControllerClass.getDeclaredMethod("getTotalQuota");
-            Method getRejectionCount = this.admissionControllerClass.getDeclaredMethod("getRejectionCount");
+            Method getUsedQuota = admissionController.getDeclaredMethod("getUsedQuota");
+            Method getTotalQuota = admissionController.getDeclaredMethod("getTotalQuota");
+            Method getRejectionCount = admissionController.getDeclaredMethod("getRejectionCount");
 
             if (!Objects.isNull(globalJVMMP)) {
                 value.append(PerformanceAnalyzerMetrics.getJsonCurrentMilliSeconds())
@@ -174,13 +170,10 @@ public class AdmissionControlMetricsCollector extends PerformanceAnalyzerMetrics
         }
     }
 
-    private boolean canLoadAdmissionControllerClasses() {
+    private boolean isAdmissionControlFeatureAvailable() {
         try {
-            ClassLoader admissionControlClassLoader = this.getClass().getClassLoader().getParent();
-            this.admissionControllerClass =
-                    Class.forName(ADMISSION_CONTROLLER, false, admissionControlClassLoader);
-            this.jettyAdmissionControllerServiceClass =
-                    Class.forName(ADMISSION_CONTROL_SERVICE, false, admissionControlClassLoader);
+            Class.forName(ADMISSION_CONTROLLER);
+            Class.forName(ADMISSION_CONTROL_SERVICE);
         } catch (ClassNotFoundException e) {
             return false;
         }


### PR DESCRIPTION
This reverts commit 7c9a49321e62f884bc7621b677ca31c7eb7b35aa, breaking the main.
```
org.opensearch.bootstrap.StartupException: java.lang.IllegalStateException: failed to load plugin class [org.opensearch.performanceanalyzer.PerformanceAnalyzerPlugin]
»  	at org.opensearch.bootstrap.OpenSearch.init(OpenSearch.java:184) ~[opensearch-3.0.0-SNAPSHOT.jar:3.0.0-SNAPSHOT]
»  	at org.opensearch.bootstrap.OpenSearch.execute(OpenSearch.java:171) ~[opensearch-3.0.0-SNAPSHOT.jar:3.0.0-SNAPSHOT]
»  	at org.opensearch.cli.EnvironmentAwareCommand.execute(EnvironmentAwareCommand.java:104) ~[opensearch-3.0.0-SNAPSHOT.jar:3.0.0-SNAPSHOT]
»  	at org.opensearch.cli.Command.mainWithoutErrorHandling(Command.java:138) ~[opensearch-cli-3.0.0-SNAPSHOT.jar:3.0.0-SNAPSHOT]
»  	at org.opensearch.cli.Command.main(Command.java:101) ~[opensearch-cli-3.0.0-SNAPSHOT.jar:3.0.0-SNAPSHOT]
»  	at org.opensearch.bootstrap.OpenSearch.main(OpenSearch.java:137) ~[opensearch-3.0.0-SNAPSHOT.jar:3.0.0-SNAPSHOT]
»  	at org.opensearch.bootstrap.OpenSearch.main(OpenSearch.java:103) ~[opensearch-3.0.0-SNAPSHOT.jar:3.0.0-SNAPSHOT]
»  Caused by: java.lang.IllegalStateException: failed to load plugin class [org.opensearch.performanceanalyzer.PerformanceAnalyzerPlugin]
»  	at org.opensearch.plugins.PluginsService.loadPlugin(PluginsService.java:791) ~[opensearch-3.0.0-SNAPSHOT.jar:3.0.0-SNAPSHOT]
...
  Caused by: java.security.AccessControlException: access denied ("java.lang.RuntimePermission" "getClassLoader")
»  	at java.security.AccessControlContext.checkPermission(AccessControlContext.java:472) ~[?:?]
»  	at java.security.AccessController.checkPermission(AccessController.java:897) ~[?:?]
»  	at java.lang.SecurityManager.checkPermission(SecurityManager.java:322) ~[?:?]
»  	at java.lang.ClassLoader.checkClassLoaderPermission(ClassLoader.java:2060) ~[?:?]
»  	at java.lang.ClassLoader.getParent(ClassLoader.java:1806) ~[?:?]
»  	at org.opensearch.performanceanalyzer.collectors.AdmissionControlMetricsCollector.canLoadAdmissionControllerClasses(AdmissionControlMetricsCollector.java:179) ~[?:?]
```

**Is your feature request related to a problem? Please provide an existing Issue # , or describe.**
A clear and concise description of what the problem is. Ex. I'm always frustrated when [...]

**Describe the solution you are proposing**
A clear and concise description of what you want to happen.

**Describe alternatives you've considered**
A clear and concise description of any alternative solutions or features you've considered.

**Additional context**
Add any other context or screenshots about the feature request here.

### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [ ] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/performance-analyzer/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
