### PR TITLE
Make netty version match the one from core.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -210,7 +210,7 @@ dependencies {
 
     def jacksonVersion = "2.14.2"
     def jacksonDataBindVersion = "2.14.2"
-    def nettyVersion = "4.1.84.Final"
+    def nettyVersion = "${versions.netty}"
 
     configurations {
         // jarHell reports class name conflicts between securemock and mockito-core


### PR DESCRIPTION
Signed-off-by: Filip Drobnjakovic <drobnjakovicfilip@gmail.com>

**Is your feature request related to a problem? Please provide an existing Issue # , or describe.**
A clear and concise description of what the problem is. Ex. I'm always frustrated when [...]

**Describe the solution you are proposing**
Matching the netty version with the one core build-tools lib.

**Describe alternatives you've considered**
A clear and concise description of any alternative solutions or features you've considered.

**Additional context**
Add any other context or screenshots about the feature request here.

### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [x] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/performance-analyzer/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
