### PR TITLE
Make dependencies match ones from core.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -259,9 +259,11 @@ checkstyleTest.enabled = false
 
 dependencies {
 
-    def jacksonVersion = "2.14.1"
-    def jacksonDataBindVersion = "2.14.1"
+    def jacksonVersion = "${versions.jackson}"
+    def jacksonDataBindVersion = "${versions.jackson_databind}"
     def nettyVersion = "${versions.netty}"
+    def junitVersion = "${versions.junit}"
+    def log4jVersion = "${versions.log4j}"
 
     configurations {
         // jarHell reports class name conflicts between securemock and mockito-core
@@ -273,7 +275,7 @@ dependencies {
 
     configurations.all {
         resolutionStrategy {
-            force 'junit:junit:4.13.1'
+            force "junit:junit:${junitVersion}"
             force "com.fasterxml.jackson.core:jackson-annotations:${jacksonVersion}"
             force "com.fasterxml.jackson.core:jackson-core:${jacksonVersion}"
             force "com.fasterxml.jackson.core:jackson-databind:${jacksonDataBindVersion}"
@@ -298,8 +300,8 @@ dependencies {
     implementation "com.fasterxml.jackson.core:jackson-annotations:${jacksonVersion}"
     implementation "com.fasterxml.jackson.core:jackson-databind:${jacksonDataBindVersion}"
     implementation "com.fasterxml.jackson.module:jackson-module-paranamer:${jacksonVersion}"
-    implementation(group: 'org.apache.logging.log4j', name: 'log4j-api', version: '2.17.1')
-    implementation(group: 'org.apache.logging.log4j', name: 'log4j-core', version: '2.17.1')
+    implementation(group: 'org.apache.logging.log4j', name: 'log4j-api', version: "${log4jVersion}")
+    implementation(group: 'org.apache.logging.log4j', name: 'log4j-core', version: "${log4jVersion}")
     implementation(group: 'com.google.errorprone', name: 'error_prone_annotations', version: '2.9.0') {
         force = 'true'
     }


### PR DESCRIPTION
Signed-off-by: Filip Drobnjakovic <drobnjakovicfilip@gmail.com>

**Is your feature request related to a problem? Please provide an existing Issue # , or describe.**
A clear and concise description of what the problem is. Ex. I'm always frustrated when [...]

**Describe the solution you are proposing**
Make junit, jackson, log4j and netty dependencies match ones from core.

**Describe alternatives you've considered**
A clear and concise description of any alternative solutions or features you've considered.

**Additional context**
Add any other context or screenshots about the feature request here.

### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [x] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/performance-analyzer/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
