### PR TITLE
Update RestController constructor for tests.

### DIFF
--- a/src/test/java/org/opensearch/performanceanalyzer/PerformanceAnalyzerPluginTests.java
+++ b/src/test/java/org/opensearch/performanceanalyzer/PerformanceAnalyzerPluginTests.java
@@ -29,6 +29,7 @@ import org.opensearch.common.settings.Setting;
 import org.opensearch.common.settings.Settings;
 import org.opensearch.env.Environment;
 import org.opensearch.env.TestEnvironment;
+import org.opensearch.identity.IdentityService;
 import org.opensearch.indices.breaker.BreakerSettings;
 import org.opensearch.indices.breaker.CircuitBreakerService;
 import org.opensearch.indices.breaker.HierarchyCircuitBreakerService;
@@ -60,6 +61,7 @@ public class PerformanceAnalyzerPluginTests extends OpenSearchTestCase {
     private CircuitBreakerService circuitBreakerService;
     private ClusterService clusterService;
     private ClusterSettings clusterSettings;
+    private IdentityService identityService;
 
     @Before
     public void setup() {
@@ -76,13 +78,15 @@ public class PerformanceAnalyzerPluginTests extends OpenSearchTestCase {
         nodeClient = new NodeClient(settings, threadPool);
         environment = TestEnvironment.newEnvironment(settings);
         clusterService = new ClusterService(settings, clusterSettings, threadPool);
+        identityService = new IdentityService(Settings.EMPTY, List.of());
         restController =
                 new RestController(
                         Collections.emptySet(),
                         null,
                         nodeClient,
                         circuitBreakerService,
-                        usageService);
+                        usageService,
+                        identityService);
     }
 
     @After

--- a/src/test/java/org/opensearch/performanceanalyzer/http_action/config/PerformanceAnalyzerClusterConfigActionTests.java
+++ b/src/test/java/org/opensearch/performanceanalyzer/http_action/config/PerformanceAnalyzerClusterConfigActionTests.java
@@ -12,6 +12,7 @@ import static org.mockito.MockitoAnnotations.initMocks;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Collections;
+import java.util.List;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
@@ -25,6 +26,7 @@ import org.opensearch.common.xcontent.XContentFactory;
 import org.opensearch.common.xcontent.XContentType;
 import org.opensearch.core.xcontent.NamedXContentRegistry;
 import org.opensearch.core.xcontent.XContentBuilder;
+import org.opensearch.identity.IdentityService;
 import org.opensearch.indices.breaker.BreakerSettings;
 import org.opensearch.indices.breaker.CircuitBreakerService;
 import org.opensearch.indices.breaker.HierarchyCircuitBreakerService;
@@ -50,6 +52,7 @@ public class PerformanceAnalyzerClusterConfigActionTests {
     private ClusterSettings clusterSettings;
     private PerformanceAnalyzerClusterSettingHandler clusterSettingHandler;
     private NodeStatsSettingHandler nodeStatsSettingHandler;
+    private IdentityService identityService;
 
     @Mock private PerformanceAnalyzerController controller;
     @Mock private ClusterSettingsManager clusterSettingsManager;
@@ -66,13 +69,15 @@ public class PerformanceAnalyzerClusterConfigActionTests {
         UsageService usageService = new UsageService();
         threadPool = new TestThreadPool("test");
         nodeClient = new NodeClient(Settings.EMPTY, threadPool);
+        identityService = new IdentityService(Settings.EMPTY, List.of());
         restController =
                 new RestController(
                         Collections.emptySet(),
                         null,
                         nodeClient,
                         circuitBreakerService,
-                        usageService);
+                        usageService,
+                        identityService);
         clusterSettingHandler =
                 new PerformanceAnalyzerClusterSettingHandler(controller, clusterSettingsManager);
         nodeStatsSettingHandler = new NodeStatsSettingHandler(controller, clusterSettingsManager);

--- a/src/test/java/org/opensearch/performanceanalyzer/http_action/config/PerformanceAnalyzerConfigActionTests.java
+++ b/src/test/java/org/opensearch/performanceanalyzer/http_action/config/PerformanceAnalyzerConfigActionTests.java
@@ -12,6 +12,7 @@ import static org.mockito.MockitoAnnotations.initMocks;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Collections;
+import java.util.List;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
@@ -26,6 +27,7 @@ import org.opensearch.common.xcontent.XContentFactory;
 import org.opensearch.common.xcontent.XContentType;
 import org.opensearch.core.xcontent.NamedXContentRegistry;
 import org.opensearch.core.xcontent.XContentBuilder;
+import org.opensearch.identity.IdentityService;
 import org.opensearch.indices.breaker.BreakerSettings;
 import org.opensearch.indices.breaker.CircuitBreakerService;
 import org.opensearch.indices.breaker.HierarchyCircuitBreakerService;
@@ -46,6 +48,7 @@ public class PerformanceAnalyzerConfigActionTests {
     private NodeClient nodeClient;
     private CircuitBreakerService circuitBreakerService;
     private ClusterSettings clusterSettings;
+    private IdentityService identityService;
 
     @Mock private PerformanceAnalyzerController controller;
 
@@ -61,13 +64,15 @@ public class PerformanceAnalyzerConfigActionTests {
         UsageService usageService = new UsageService();
         threadPool = new TestThreadPool("test");
         nodeClient = new NodeClient(Settings.EMPTY, threadPool);
+        identityService = new IdentityService(Settings.EMPTY, List.of());
         restController =
                 new RestController(
                         Collections.emptySet(),
                         null,
                         nodeClient,
                         circuitBreakerService,
-                        usageService);
+                        usageService,
+                        identityService);
         configAction = new PerformanceAnalyzerConfigAction(restController, controller);
         restController.registerHandler(configAction);
 

--- a/src/test/java/org/opensearch/performanceanalyzer/http_action/config/PerformanceAnalyzerOverridesClusterConfigActionTests.java
+++ b/src/test/java/org/opensearch/performanceanalyzer/http_action/config/PerformanceAnalyzerOverridesClusterConfigActionTests.java
@@ -13,6 +13,7 @@ import java.io.IOException;
 import java.nio.ByteBuffer;
 import java.util.ArrayList;
 import java.util.Collections;
+import java.util.List;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
@@ -24,6 +25,7 @@ import org.opensearch.common.settings.Settings;
 import org.opensearch.common.util.concurrent.ThreadContext;
 import org.opensearch.common.xcontent.XContentType;
 import org.opensearch.core.xcontent.NamedXContentRegistry;
+import org.opensearch.identity.IdentityService;
 import org.opensearch.indices.breaker.BreakerSettings;
 import org.opensearch.indices.breaker.CircuitBreakerService;
 import org.opensearch.indices.breaker.HierarchyCircuitBreakerService;
@@ -46,6 +48,7 @@ public class PerformanceAnalyzerOverridesClusterConfigActionTests {
     private NodeClient nodeClient;
     private CircuitBreakerService circuitBreakerService;
     private ClusterSettings clusterSettings;
+    private IdentityService identityService;
 
     @Mock private ConfigOverridesClusterSettingHandler configOverridesClusterSettingHandler;
     @Mock private ConfigOverridesWrapper overridesWrapper;
@@ -62,13 +65,15 @@ public class PerformanceAnalyzerOverridesClusterConfigActionTests {
         UsageService usageService = new UsageService();
         threadPool = new TestThreadPool("test");
         nodeClient = new NodeClient(Settings.EMPTY, threadPool);
+        identityService = new IdentityService(Settings.EMPTY, List.of());
         restController =
                 new RestController(
                         Collections.emptySet(),
                         null,
                         nodeClient,
                         circuitBreakerService,
-                        usageService);
+                        usageService,
+                        identityService);
         configAction =
                 new PerformanceAnalyzerOverridesClusterConfigAction(
                         Settings.EMPTY,


### PR DESCRIPTION
Due to https://github.com/opensearch-project/OpenSearch/pull/7246, added dummy `IdentityService` objects into `ResController` constructors used in tests.

### Check List
- [ ] New functionality includes testing.
  - [x]  All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [x] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/performance-analyzer/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
