### PR TITLE
revert the routingTable.indicesRouting.keySet change

### DIFF
--- a/src/main/java/org/opensearch/performanceanalyzer/collectors/ShardStateCollector.java
+++ b/src/main/java/org/opensearch/performanceanalyzer/collectors/ShardStateCollector.java
@@ -68,7 +68,7 @@ public class ShardStateCollector extends PerformanceAnalyzerMetricsCollector
         value.append(PerformanceAnalyzerMetrics.getJsonCurrentMilliSeconds())
                 .append(PerformanceAnalyzerMetrics.sMetricNewLineDelimitor);
         RoutingTable routingTable = clusterState.routingTable();
-        String[] indices = routingTable.indicesRouting().keySet().toArray(new String[0]);
+        String[] indices = routingTable.indicesRouting().keys().toArray(String.class);
         for (String index : indices) {
             List<ShardRouting> allShardsIndex = routingTable.allShards(index);
             value.append(


### PR DESCRIPTION
**Is your feature request related to a problem? Please provide an existing Issue # , or describe.**
Revert the routingTable.indicesRouting.keySet change for 2.8 release since the necessary OpenSearch side changes are not in yet.

**Additional context**
Add any other context or screenshots about the feature request here.

### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [ ] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/performance-analyzer/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
