### PR TITLE
Update guava to address CVE-2023-2976

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -240,7 +240,7 @@ dependencies {
         }
     }
 
-    compile('com.google.guava:guava:30.1-jre') {
+    compile('com.google.guava:guava:32.0.1-jre') {
         force = 'true'
     }
     compile 'org.jooq:jooq:3.10.8'


### PR DESCRIPTION
Update guava to address [CVE-2023-2976](https://www.cve.org/CVERecord?id=CVE-2023-2976).

### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [x] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/performance-analyzer/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
