### PR TITLE
Remove usage of deprecated "master" APIs

### DIFF
--- a/src/main/java/org/opensearch/performanceanalyzer/collectors/ClusterManagerServiceEventMetrics.java
+++ b/src/main/java/org/opensearch/performanceanalyzer/collectors/ClusterManagerServiceEventMetrics.java
@@ -17,7 +17,7 @@ import java.util.*;
 import java.util.concurrent.ThreadPoolExecutor;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
-import org.opensearch.cluster.service.MasterService;
+import org.opensearch.cluster.service.ClusterManagerService;
 import org.opensearch.cluster.service.SourcePrioritizedRunnable;
 import org.opensearch.common.util.concurrent.PrioritizedOpenSearchThreadPoolExecutor;
 import org.opensearch.performanceanalyzer.OpenSearchResources;
@@ -82,7 +82,9 @@ public class ClusterManagerServiceEventMetrics extends PerformanceAnalyzerMetric
         try {
             if (Objects.isNull(OpenSearchResources.INSTANCE.getClusterService())
                     || Objects.isNull(
-                            OpenSearchResources.INSTANCE.getClusterService().getMasterService())) {
+                            OpenSearchResources.INSTANCE
+                                    .getClusterService()
+                                    .getClusterManagerService())) {
                 return;
             }
 
@@ -186,7 +188,8 @@ public class ClusterManagerServiceEventMetrics extends PerformanceAnalyzerMetric
 
     // - Separated to have a unit test; and catch any code changes around this field
     Field getClusterManagerServiceTPExecutorField() throws NoSuchFieldException {
-        Field threadPoolExecutorField = MasterService.class.getDeclaredField("threadPoolExecutor");
+        Field threadPoolExecutorField =
+                ClusterManagerService.class.getDeclaredField("threadPoolExecutor");
         threadPoolExecutorField.setAccessible(true);
         return threadPoolExecutorField;
     }
@@ -223,8 +226,8 @@ public class ClusterManagerServiceEventMetrics extends PerformanceAnalyzerMetric
             throws NoSuchFieldException, IllegalAccessException {
         if (clusterManagerServiceCurrentQueue == null) {
             if (OpenSearchResources.INSTANCE.getClusterService() != null) {
-                MasterService clusterManagerService =
-                        OpenSearchResources.INSTANCE.getClusterService().getMasterService();
+                ClusterManagerService clusterManagerService =
+                        OpenSearchResources.INSTANCE.getClusterService().getClusterManagerService();
 
                 if (clusterManagerService != null) {
                     if (prioritizedOpenSearchThreadPoolExecutor == null) {
@@ -253,8 +256,8 @@ public class ClusterManagerServiceEventMetrics extends PerformanceAnalyzerMetric
             throws NoSuchFieldException, IllegalAccessException {
         if (clusterManagerServiceWorkers == null) {
             if (OpenSearchResources.INSTANCE.getClusterService() != null) {
-                MasterService clusterManagerService =
-                        OpenSearchResources.INSTANCE.getClusterService().getMasterService();
+                ClusterManagerService clusterManagerService =
+                        OpenSearchResources.INSTANCE.getClusterService().getClusterManagerService();
 
                 if (clusterManagerService != null) {
                     if (prioritizedOpenSearchThreadPoolExecutor == null) {

--- a/src/main/java/org/opensearch/performanceanalyzer/collectors/ClusterManagerServiceMetrics.java
+++ b/src/main/java/org/opensearch/performanceanalyzer/collectors/ClusterManagerServiceMetrics.java
@@ -59,7 +59,9 @@ public class ClusterManagerServiceMetrics extends PerformanceAnalyzerMetricsColl
     public void collectMetrics(long startTime) {
         if (Objects.isNull(OpenSearchResources.INSTANCE.getClusterService())
                 || Objects.isNull(
-                        OpenSearchResources.INSTANCE.getClusterService().getMasterService())) {
+                        OpenSearchResources.INSTANCE
+                                .getClusterService()
+                                .getClusterManagerService())) {
             return;
         }
 
@@ -72,7 +74,10 @@ public class ClusterManagerServiceMetrics extends PerformanceAnalyzerMetricsColl
          *      timeIn_queue: "86ms"
          */
         List<PendingClusterTask> pendingTasks =
-                OpenSearchResources.INSTANCE.getClusterService().getMasterService().pendingTasks();
+                OpenSearchResources.INSTANCE
+                        .getClusterService()
+                        .getClusterManagerService()
+                        .pendingTasks();
         HashMap<String, Integer> pendingTaskCountPerTaskType = new HashMap<>();
 
         pendingTasks.stream()

--- a/src/main/java/org/opensearch/performanceanalyzer/collectors/ClusterManagerThrottlingMetricsCollector.java
+++ b/src/main/java/org/opensearch/performanceanalyzer/collectors/ClusterManagerThrottlingMetricsCollector.java
@@ -14,7 +14,7 @@ import java.lang.reflect.Method;
 import java.util.Objects;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
-import org.opensearch.cluster.service.MasterService;
+import org.opensearch.cluster.service.ClusterManagerService;
 import org.opensearch.performanceanalyzer.OpenSearchResources;
 import org.opensearch.performanceanalyzer.commons.collectors.MetricStatus;
 import org.opensearch.performanceanalyzer.commons.collectors.PerformanceAnalyzerMetricsCollector;
@@ -67,7 +67,9 @@ public class ClusterManagerThrottlingMetricsCollector extends PerformanceAnalyze
         }
         if (Objects.isNull(OpenSearchResources.INSTANCE.getClusterService())
                 || Objects.isNull(
-                        OpenSearchResources.INSTANCE.getClusterService().getMasterService())) {
+                        OpenSearchResources.INSTANCE
+                                .getClusterService()
+                                .getClusterManagerService())) {
             return;
         }
 
@@ -105,7 +107,7 @@ public class ClusterManagerThrottlingMetricsCollector extends PerformanceAnalyze
     private boolean isClusterManagerThrottlingFeatureAvailable() {
         try {
             Class.forName(CLUSTER_MANAGER_THROTTLING_RETRY_LISTENER_PATH);
-            MasterService.class.getMethod(THROTTLED_PENDING_TASK_COUNT_METHOD_NAME);
+            ClusterManagerService.class.getMethod(THROTTLED_PENDING_TASK_COUNT_METHOD_NAME);
         } catch (ClassNotFoundException | NoSuchMethodException e) {
             return false;
         }
@@ -114,9 +116,13 @@ public class ClusterManagerThrottlingMetricsCollector extends PerformanceAnalyze
 
     private long getTotalClusterManagerThrottledTaskCount()
             throws NoSuchMethodException, InvocationTargetException, IllegalAccessException {
-        Method method = MasterService.class.getMethod(THROTTLED_PENDING_TASK_COUNT_METHOD_NAME);
+        Method method =
+                ClusterManagerService.class.getMethod(THROTTLED_PENDING_TASK_COUNT_METHOD_NAME);
         return (long)
-                method.invoke(OpenSearchResources.INSTANCE.getClusterService().getMasterService());
+                method.invoke(
+                        OpenSearchResources.INSTANCE
+                                .getClusterService()
+                                .getClusterManagerService());
     }
 
     private long getRetryingPendingTaskCount()

--- a/src/main/java/org/opensearch/performanceanalyzer/collectors/NodeDetailsCollector.java
+++ b/src/main/java/org/opensearch/performanceanalyzer/collectors/NodeDetailsCollector.java
@@ -89,7 +89,7 @@ public class NodeDetailsCollector extends PerformanceAnalyzerMetricsCollector
         DiscoveryNodes discoveryNodes =
                 OpenSearchResources.INSTANCE.getClusterService().state().nodes();
 
-        DiscoveryNode clusterManagerNode = discoveryNodes.getMasterNode();
+        DiscoveryNode clusterManagerNode = discoveryNodes.getClusterManagerNode();
 
         Iterator<DiscoveryNode> discoveryNodeIterator = discoveryNodes.iterator();
         addMetricsToStringBuilder(discoveryNodes.getLocalNode(), value, "", clusterManagerNode);
@@ -124,7 +124,7 @@ public class NodeDetailsCollector extends PerformanceAnalyzerMetricsCollector
         final NodeRole role =
                 node.isDataNode()
                         ? NodeRole.DATA
-                        : node.isMasterNode() ? NodeRole.CLUSTER_MANAGER : NodeRole.UNKNOWN;
+                        : node.isClusterManagerNode() ? NodeRole.CLUSTER_MANAGER : NodeRole.UNKNOWN;
         return role.toString();
     }
 

--- a/src/test/java/org/opensearch/performanceanalyzer/collectors/ClusterManagerServiceEventMetricsTests.java
+++ b/src/test/java/org/opensearch/performanceanalyzer/collectors/ClusterManagerServiceEventMetricsTests.java
@@ -119,7 +119,7 @@ public class ClusterManagerServiceEventMetricsTests {
                                 .get(
                                         OpenSearchResources.INSTANCE
                                                 .getClusterService()
-                                                .getMasterService());
+                                                .getClusterManagerService());
         SourcePrioritizedRunnable runnable =
                 new SourcePrioritizedRunnable(Priority.HIGH, "_add_listener_") {
                     @Override

--- a/src/test/java/org/opensearch/performanceanalyzer/collectors/ClusterManagerServiceMetricsTests.java
+++ b/src/test/java/org/opensearch/performanceanalyzer/collectors/ClusterManagerServiceMetricsTests.java
@@ -94,7 +94,7 @@ public class ClusterManagerServiceMetricsTests {
         assertNull(jsonStr);
 
         OpenSearchResources.INSTANCE.setClusterService(mockedClusterService);
-        when(mockedClusterService.getMasterService()).thenThrow(new RuntimeException());
+        when(mockedClusterService.getClusterManagerService()).thenThrow(new RuntimeException());
         clusterManagerServiceMetrics.run();
         jsonStr = readMetricsInJsonString(0);
         assertNull(jsonStr);

--- a/src/test/java/org/opensearch/performanceanalyzer/hwnet/CollectMetricsTests.java
+++ b/src/test/java/org/opensearch/performanceanalyzer/hwnet/CollectMetricsTests.java
@@ -493,7 +493,7 @@ public class CollectMetricsTests extends AbstractTests {
             discoBuilder = discoBuilder.add(node);
         }
 
-        discoBuilder.masterNodeId(nodeId1);
+        discoBuilder.clusterManagerNodeId(nodeId1);
         discoBuilder.localNodeId(nodeId2);
 
         DiscoveryNodes discoveryNodes = discoBuilder.build();


### PR DESCRIPTION
All usages have been replaced with the "cluster manager" variants.

**Additional context**
I'm looking at removing MasterService in the core repo and this appears to be the only remaining reference outside of core. Note the build appears to be broken on main (?) but this commit can be cleanly cherry picked on to the 2.x branch where it will compile successfully.

Here is the closed issue that refers to removing deprecated APIs: #152

### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [x] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/performance-analyzer/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
