### PR TITLE
Add separate metric for cluster manager service events and metrics

### DIFF
--- a/src/main/java/org/opensearch/performanceanalyzer/collectors/ClusterManagerServiceEventMetrics.java
+++ b/src/main/java/org/opensearch/performanceanalyzer/collectors/ClusterManagerServiceEventMetrics.java
@@ -5,8 +5,8 @@
 
 package org.opensearch.performanceanalyzer.collectors;
 
-import static org.opensearch.performanceanalyzer.commons.stats.metrics.StatExceptionCode.CLUSTER_MANAGER_METRICS_ERROR;
 import static org.opensearch.performanceanalyzer.commons.stats.metrics.StatExceptionCode.CLUSTER_MANAGER_NODE_NOT_UP;
+import static org.opensearch.performanceanalyzer.commons.stats.metrics.StatExceptionCode.CLUSTER_MANAGER_SERVICE_EVENTS_METRICS_COLLECTOR_ERROR;
 import static org.opensearch.performanceanalyzer.commons.stats.metrics.StatMetrics.CLUSTER_MANAGER_SERVICE_EVENTS_METRICS_COLLECTOR_EXECUTION_TIME;
 
 import com.google.common.annotations.VisibleForTesting;
@@ -51,7 +51,7 @@ public class ClusterManagerServiceEventMetrics extends PerformanceAnalyzerMetric
                 SAMPLING_TIME_INTERVAL,
                 "ClusterManagerServiceEventMetrics",
                 CLUSTER_MANAGER_SERVICE_EVENTS_METRICS_COLLECTOR_EXECUTION_TIME,
-                CLUSTER_MANAGER_METRICS_ERROR);
+                CLUSTER_MANAGER_SERVICE_EVENTS_METRICS_COLLECTOR_ERROR);
         clusterManagerServiceCurrentQueue = null;
         clusterManagerServiceWorkers = null;
         prioritizedOpenSearchThreadPoolExecutor = null;
@@ -163,7 +163,8 @@ public class ClusterManagerServiceEventMetrics extends PerformanceAnalyzerMetric
                     "[ {} ] Exception raised while getting Cluster Manager throttling metrics: {} ",
                     this::getCollectorName,
                     e::getMessage);
-            StatsCollector.instance().logException(CLUSTER_MANAGER_METRICS_ERROR);
+            StatsCollector.instance()
+                    .logException(CLUSTER_MANAGER_SERVICE_EVENTS_METRICS_COLLECTOR_ERROR);
         }
     }
 

--- a/src/main/java/org/opensearch/performanceanalyzer/collectors/ClusterManagerServiceMetrics.java
+++ b/src/main/java/org/opensearch/performanceanalyzer/collectors/ClusterManagerServiceMetrics.java
@@ -5,7 +5,6 @@
 
 package org.opensearch.performanceanalyzer.collectors;
 
-import static org.opensearch.performanceanalyzer.commons.stats.metrics.StatExceptionCode.CLUSTER_MANAGER_METRICS_ERROR;
 import static org.opensearch.performanceanalyzer.commons.stats.metrics.StatMetrics.CLUSTER_MANAGER_SERVICE_METRICS_COLLECTOR_EXECUTION_TIME;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
@@ -39,7 +38,7 @@ public class ClusterManagerServiceMetrics extends PerformanceAnalyzerMetricsColl
                 SAMPLING_TIME_INTERVAL,
                 "ClusterManagerServiceMetrics",
                 CLUSTER_MANAGER_SERVICE_METRICS_COLLECTOR_EXECUTION_TIME,
-                CLUSTER_MANAGER_METRICS_ERROR);
+                CLUSTER_MANAGER_SERVICE_METRICS_COLLECTOR_ERROR);
         value = new StringBuilder();
     }
 

--- a/src/main/java/org/opensearch/performanceanalyzer/collectors/ClusterManagerServiceMetrics.java
+++ b/src/main/java/org/opensearch/performanceanalyzer/collectors/ClusterManagerServiceMetrics.java
@@ -5,6 +5,7 @@
 
 package org.opensearch.performanceanalyzer.collectors;
 
+import static org.opensearch.performanceanalyzer.commons.stats.metrics.StatExceptionCode.CLUSTER_MANAGER_SERVICE_METRICS_COLLECTOR_ERROR;
 import static org.opensearch.performanceanalyzer.commons.stats.metrics.StatMetrics.CLUSTER_MANAGER_SERVICE_METRICS_COLLECTOR_EXECUTION_TIME;
 
 import com.fasterxml.jackson.annotation.JsonProperty;

--- a/src/test/java/org/opensearch/performanceanalyzer/collectors/StatsTests.java
+++ b/src/test/java/org/opensearch/performanceanalyzer/collectors/StatsTests.java
@@ -43,13 +43,13 @@ public class StatsTests {
 
     static Random RANDOM = new Random();
     private static final int MAX_COUNT = 500;
-    private static final int CLUSTER_MANAGER_METRICS_ERRORS =
+    private static final int CLUSTER_MANAGER_SERVICE_EVENTS_METRICS_ERROR =
             Math.abs(RANDOM.nextInt() % MAX_COUNT);
     private static final int REQUEST_REMOTE_ERRORS = Math.abs(RANDOM.nextInt() % MAX_COUNT);
     private static final int READER_PARSER_ERRORS = Math.abs(RANDOM.nextInt() % MAX_COUNT);
     private static final int READER_RESTART_PROCESSINGS = Math.abs(RANDOM.nextInt() % MAX_COUNT);
     private static final int TOTAL_ERRORS =
-            CLUSTER_MANAGER_METRICS_ERRORS
+            CLUSTER_MANAGER_SERVICE_EVENTS_METRICS_ERROR
                     + REQUEST_REMOTE_ERRORS
                     + READER_PARSER_ERRORS
                     + READER_RESTART_PROCESSINGS;
@@ -63,7 +63,7 @@ public class StatsTests {
 
         LinkedList<StatExceptionCode> exceptionCodeList = new LinkedList<>();
 
-        for (int i = 0; i < CLUSTER_MANAGER_SERVICE_EVENTS_METRICS_COLLECTOR_ERROR; i++) {
+        for (int i = 0; i < CLUSTER_MANAGER_SERVICE_EVENTS_METRICS_ERROR; i++) {
             exceptionCodeList.add(
                     StatExceptionCode.CLUSTER_MANAGER_SERVICE_EVENTS_METRICS_COLLECTOR_ERROR);
         }
@@ -107,7 +107,7 @@ public class StatsTests {
                                         .toString(),
                                 DEFAULT_VAL)
                         .get(),
-                CLUSTER_MANAGER_SERVICE_EVENTS_METRICS_COLLECTOR_ERROR);
+                CLUSTER_MANAGER_SERVICE_EVENTS_METRICS_ERROR);
         assertEquals(
                 sc.getCounters()
                         .getOrDefault(

--- a/src/test/java/org/opensearch/performanceanalyzer/collectors/StatsTests.java
+++ b/src/test/java/org/opensearch/performanceanalyzer/collectors/StatsTests.java
@@ -63,8 +63,9 @@ public class StatsTests {
 
         LinkedList<StatExceptionCode> exceptionCodeList = new LinkedList<>();
 
-        for (int i = 0; i < CLUSTER_MANAGER_METRICS_ERRORS; i++) {
-            exceptionCodeList.add(StatExceptionCode.CLUSTER_MANAGER_METRICS_ERROR);
+        for (int i = 0; i < CLUSTER_MANAGER_SERVICE_EVENTS_METRICS_COLLECTOR_ERROR; i++) {
+            exceptionCodeList.add(
+                    StatExceptionCode.CLUSTER_MANAGER_SERVICE_EVENTS_METRICS_COLLECTOR_ERROR);
         }
 
         for (int i = 0; i < REQUEST_REMOTE_ERRORS; i++) {
@@ -101,10 +102,12 @@ public class StatsTests {
         assertEquals(
                 sc.getCounters()
                         .getOrDefault(
-                                StatExceptionCode.CLUSTER_MANAGER_METRICS_ERROR.toString(),
+                                StatExceptionCode
+                                        .CLUSTER_MANAGER_SERVICE_EVENTS_METRICS_COLLECTOR_ERROR
+                                        .toString(),
                                 DEFAULT_VAL)
                         .get(),
-                CLUSTER_MANAGER_METRICS_ERRORS);
+                CLUSTER_MANAGER_SERVICE_EVENTS_METRICS_COLLECTOR_ERROR);
         assertEquals(
                 sc.getCounters()
                         .getOrDefault(


### PR DESCRIPTION
Related commit in Commons: https://github.com/opensearch-project/performance-analyzer-commons/commit/83cb2d427f28c9e814150d079f32be1a88b41446 

### Check List
- [x] Backport Labels added.
- [ ] New functionality includes testing.
  - [x] All tests pass
- [ ] New functionality has been documented.
  - [x] New functionality has javadoc added
- [x] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/performance-analyzer/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
