### PR TITLE
Ensure that PATransportChannel delegates to wrapped channel and add tests

### DIFF
--- a/src/main/java/org/opensearch/performanceanalyzer/transport/PerformanceAnalyzerTransportChannel.java
+++ b/src/main/java/org/opensearch/performanceanalyzer/transport/PerformanceAnalyzerTransportChannel.java
@@ -7,9 +7,11 @@ package org.opensearch.performanceanalyzer.transport;
 
 
 import java.io.IOException;
+import java.util.Optional;
 import java.util.concurrent.atomic.AtomicLong;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
+import org.opensearch.Version;
 import org.opensearch.core.transport.TransportResponse;
 import org.opensearch.performanceanalyzer.commons.metrics.AllMetrics.ShardBulkDimension;
 import org.opensearch.performanceanalyzer.commons.metrics.AllMetrics.ShardBulkMetric;
@@ -78,6 +80,11 @@ public class PerformanceAnalyzerTransportChannel implements TransportChannel, Me
     }
 
     @Override
+    public Version getVersion() {
+        return original.getVersion();
+    }
+
+    @Override
     public String getProfileName() {
         return "PerformanceAnalyzerTransportChannelProfile";
     }
@@ -85,6 +92,11 @@ public class PerformanceAnalyzerTransportChannel implements TransportChannel, Me
     @Override
     public String getChannelType() {
         return "PerformanceAnalyzerTransportChannelType";
+    }
+
+    @Override
+    public <T> Optional<T> get(String name, Class<T> clazz) {
+        return original.get(name, clazz);
     }
 
     @Override


### PR DESCRIPTION
**Is your feature request related to a problem? Please provide an existing Issue # , or describe.**

Ensures that PATransportChannel delegates implementations to the wrapped channel except for:

- getChannelType
- getProfileName

Added tests that use reflection to ensure that if the TransportChannel interface changes that the CI in this repo catches it to ensure that this wrapper class gets modified accordingly.

**Additional context**

https://github.com/opensearch-project/performance-analyzer/issues/606

### Check List
- [ ] Backport Labels added.
- [ ] New functionality includes testing.
  - [ ] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [ ] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/performance-analyzer/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
