### PR TITLE
Fixed the bug in CacheConfigMetricsCollector

### DIFF
--- a/src/main/java/org/opensearch/performanceanalyzer/collectors/CacheConfigMetricsCollector.java
+++ b/src/main/java/org/opensearch/performanceanalyzer/collectors/CacheConfigMetricsCollector.java
@@ -17,6 +17,8 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import java.security.AccessController;
 import java.security.PrivilegedAction;
 import org.apache.commons.lang3.reflect.FieldUtils;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 import org.opensearch.common.cache.Cache;
 import org.opensearch.indices.IndicesService;
 import org.opensearch.performanceanalyzer.OpenSearchResources;
@@ -43,6 +45,7 @@ public class CacheConfigMetricsCollector extends PerformanceAnalyzerMetricsColle
         implements MetricsProcessor {
     public static final int SAMPLING_TIME_INTERVAL =
             MetricsConfiguration.CONFIG_MAP.get(CacheConfigMetricsCollector.class).samplingInterval;
+    private static final Logger LOG = LogManager.getLogger(CacheConfigMetricsCollector.class);
     private static final int KEYS_PATH_LENGTH = 0;
     private StringBuilder value;
 
@@ -122,7 +125,7 @@ public class CacheConfigMetricsCollector extends PerformanceAnalyzerMetricsColle
                                                 SHARD_REQUEST_CACHE.toString(),
                                                 requestCacheMaxSize);
                                     } catch (Exception e) {
-                                        e.printStackTrace();
+                                        LOG.error("Error while evaluating requestCacheMaxSize", e);
                                         return null;
                                     }
                                 });

--- a/src/main/java/org/opensearch/performanceanalyzer/collectors/CacheConfigMetricsCollector.java
+++ b/src/main/java/org/opensearch/performanceanalyzer/collectors/CacheConfigMetricsCollector.java
@@ -104,10 +104,14 @@ public class CacheConfigMetricsCollector extends PerformanceAnalyzerMetricsColle
                                                         indicesService,
                                                         "indicesRequestCache",
                                                         true);
+                                        Object openSearchOnHeapCache =
+                                                FieldUtils.readField(reqCache, "cache", true);
                                         Cache requestCache =
                                                 (Cache)
                                                         FieldUtils.readField(
-                                                                reqCache, "cache", true);
+                                                                openSearchOnHeapCache,
+                                                                "cache",
+                                                                true);
                                         Long requestCacheMaxSize =
                                                 (Long)
                                                         FieldUtils.readField(
@@ -118,10 +122,15 @@ public class CacheConfigMetricsCollector extends PerformanceAnalyzerMetricsColle
                                                 SHARD_REQUEST_CACHE.toString(),
                                                 requestCacheMaxSize);
                                     } catch (Exception e) {
-                                        return new CacheMaxSizeStatus(
-                                                SHARD_REQUEST_CACHE.toString(), null);
+                                        e.printStackTrace();
+                                        return null;
                                     }
                                 });
+
+        if (shardRequestCacheMaxSizeStatus == null) {
+            return;
+        }
+
         value.append(PerformanceAnalyzerMetrics.sMetricNewLineDelimitor)
                 .append(shardRequestCacheMaxSizeStatus.serialize());
         saveMetricValues(value.toString(), startTime);


### PR DESCRIPTION
**Is your feature request related to a problem? Please provide an existing Issue # , or describe.**
Resolves #644 

Metrics are being emitted as expected:
```
^cache_config
{"current_time":1717142304989}
{"CacheType":"field_data_cache","Cache_MaxSize":-1}
{"CacheType":"shard_request_cache","Cache_MaxSize":10737418}$
```

**Describe the solution you are proposing**
Tiered Caching has introduced a new ICache interface which has an OnHeap implementation which actually stores the Cache field now. We had to update the logic to how to get the cache field. Relevant PR: https://github.com/opensearch-project/OpenSearch/pull/10753

**Describe alternatives you've considered**
A clear and concise description of any alternative solutions or features you've considered.

**Additional context**
Add any other context or screenshots about the feature request here.

### Check List
- [x] Backport Labels added.
- [x] New functionality includes testing.
  - [x] All tests pass
- [x] New functionality has been documented.
  - [x] New functionality has javadoc added
- [x] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/performance-analyzer/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
