### PR TITLE
Upgrading org.bouncycastle:bcprov-jdk15to18 to 1.78

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -301,7 +301,7 @@ dependencies {
 
     implementation 'org.jooq:jooq:3.10.8'
     implementation 'org.apache.commons:commons-lang3:3.9'
-    implementation 'org.bouncycastle:bcprov-jdk15to18:1.74'
+    implementation 'org.bouncycastle:bcprov-jdk15to18:1.78'
     implementation 'org.bouncycastle:bcpkix-jdk18on:1.74'
     implementation "org.opensearch:performance-analyzer-commons:${paCommonsVersion}"
     implementation "com.fasterxml.jackson.core:jackson-annotations:${jacksonVersion}"


### PR DESCRIPTION
**Context**
Upgrading org.bouncycastle:bcprov-jdk15to18 to 1.78
CVE - https://www.mend.io/vulnerability-database/CVE-2024-29857

### Check List
- [ ] Backport Labels added.
- [ ] New functionality includes testing.
  - [ ] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [ ] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/performance-analyzer/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
