### PR TITLE
Adds the listener for resource utilization metrics

### DIFF
--- a/src/main/java/org/opensearch/performanceanalyzer/PerformanceAnalyzerPlugin.java
+++ b/src/main/java/org/opensearch/performanceanalyzer/PerformanceAnalyzerPlugin.java
@@ -86,7 +86,9 @@ import org.opensearch.performanceanalyzer.http_action.config.PerformanceAnalyzer
 import org.opensearch.performanceanalyzer.http_action.whoami.TransportWhoAmIAction;
 import org.opensearch.performanceanalyzer.http_action.whoami.WhoAmIAction;
 import org.opensearch.performanceanalyzer.listener.PerformanceAnalyzerSearchListener;
+import org.opensearch.performanceanalyzer.listener.RTFPerformanceAnalyzerSearchListener;
 import org.opensearch.performanceanalyzer.transport.PerformanceAnalyzerTransportInterceptor;
+import org.opensearch.performanceanalyzer.transport.RTFPerformanceAnalyzerTransportInterceptor;
 import org.opensearch.performanceanalyzer.util.Utils;
 import org.opensearch.performanceanalyzer.writer.EventLogQueueProcessor;
 import org.opensearch.plugins.ActionPlugin;
@@ -302,7 +304,10 @@ public final class PerformanceAnalyzerPlugin extends Plugin
     public void onIndexModule(IndexModule indexModule) {
         PerformanceAnalyzerSearchListener performanceanalyzerSearchListener =
                 new PerformanceAnalyzerSearchListener(performanceAnalyzerController);
+        RTFPerformanceAnalyzerSearchListener rtfPerformanceAnalyzerSearchListener =
+                new RTFPerformanceAnalyzerSearchListener(performanceAnalyzerController);
         indexModule.addSearchOperationListener(performanceanalyzerSearchListener);
+        indexModule.addSearchOperationListener(rtfPerformanceAnalyzerSearchListener);
     }
 
     // follower check, leader check
@@ -330,8 +335,9 @@ public final class PerformanceAnalyzerPlugin extends Plugin
     @Override
     public List<TransportInterceptor> getTransportInterceptors(
             NamedWriteableRegistry namedWriteableRegistry, ThreadContext threadContext) {
-        return singletonList(
-                new PerformanceAnalyzerTransportInterceptor(performanceAnalyzerController));
+        return Arrays.asList(
+                new PerformanceAnalyzerTransportInterceptor(performanceAnalyzerController),
+                new RTFPerformanceAnalyzerTransportInterceptor(performanceAnalyzerController));
     }
 
     @Override

--- a/src/main/java/org/opensearch/performanceanalyzer/config/PerformanceAnalyzerController.java
+++ b/src/main/java/org/opensearch/performanceanalyzer/config/PerformanceAnalyzerController.java
@@ -383,4 +383,13 @@ public class PerformanceAnalyzerController {
 
         return disabledCollectorsList.contains(collectorName);
     }
+
+    /**
+     * Collectors Setting value.
+     *
+     * @return collectorsSettingValue
+     */
+    public int getCollectorsSettingValue() {
+        return collectorsSettingValue;
+    }
 }

--- a/src/main/java/org/opensearch/performanceanalyzer/config/PerformanceAnalyzerController.java
+++ b/src/main/java/org/opensearch/performanceanalyzer/config/PerformanceAnalyzerController.java
@@ -389,7 +389,7 @@ public class PerformanceAnalyzerController {
      *
      * @return collectorsSettingValue
      */
-    public int getCollectorsSettingValue() {
+    public int getCollectorsRunModeValue() {
         return collectorsSettingValue;
     }
 }

--- a/src/main/java/org/opensearch/performanceanalyzer/listener/PerformanceAnalyzerSearchListener.java
+++ b/src/main/java/org/opensearch/performanceanalyzer/listener/PerformanceAnalyzerSearchListener.java
@@ -45,8 +45,8 @@ public class PerformanceAnalyzerSearchListener
 
     private boolean isSearchListenerEnabled() {
         return controller.isPerformanceAnalyzerEnabled()
-                && (controller.getCollectorsSettingValue() == Util.CollectorMode.DUAL.getValue()
-                        || controller.getCollectorsSettingValue()
+                && (controller.getCollectorsRunModeValue() == Util.CollectorMode.DUAL.getValue()
+                        || controller.getCollectorsRunModeValue()
                                 == Util.CollectorMode.RCA.getValue());
     }
 

--- a/src/main/java/org/opensearch/performanceanalyzer/listener/PerformanceAnalyzerSearchListener.java
+++ b/src/main/java/org/opensearch/performanceanalyzer/listener/PerformanceAnalyzerSearchListener.java
@@ -7,6 +7,7 @@ package org.opensearch.performanceanalyzer.listener;
 
 import static org.opensearch.performanceanalyzer.commons.stats.metrics.StatExceptionCode.OPENSEARCH_REQUEST_INTERCEPTOR_ERROR;
 
+import com.google.common.annotations.VisibleForTesting;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.opensearch.index.shard.SearchOperationListener;
@@ -16,6 +17,7 @@ import org.opensearch.performanceanalyzer.commons.metrics.AllMetrics.CommonMetri
 import org.opensearch.performanceanalyzer.commons.metrics.MetricsProcessor;
 import org.opensearch.performanceanalyzer.commons.metrics.PerformanceAnalyzerMetrics;
 import org.opensearch.performanceanalyzer.commons.util.ThreadIDUtil;
+import org.opensearch.performanceanalyzer.commons.util.Util;
 import org.opensearch.performanceanalyzer.config.PerformanceAnalyzerController;
 import org.opensearch.search.internal.SearchContext;
 
@@ -36,8 +38,16 @@ public class PerformanceAnalyzerSearchListener
         return PerformanceAnalyzerSearchListener.class.getSimpleName();
     }
 
-    private SearchListener getSearchListener() {
-        return controller.isPerformanceAnalyzerEnabled() ? this : NO_OP_SEARCH_LISTENER;
+    @VisibleForTesting
+    SearchListener getSearchListener() {
+        return isSearchListenerEnabled() ? this : NO_OP_SEARCH_LISTENER;
+    }
+
+    private boolean isSearchListenerEnabled() {
+        return controller.isPerformanceAnalyzerEnabled()
+                && (controller.getCollectorsSettingValue() == Util.CollectorMode.DUAL.getValue()
+                        || controller.getCollectorsSettingValue()
+                                == Util.CollectorMode.RCA.getValue());
     }
 
     @Override

--- a/src/main/java/org/opensearch/performanceanalyzer/listener/RTFPerformanceAnalyzerSearchListener.java
+++ b/src/main/java/org/opensearch/performanceanalyzer/listener/RTFPerformanceAnalyzerSearchListener.java
@@ -218,7 +218,11 @@ public class RTFPerformanceAnalyzerSearchListener
     }
 
     private void addResourceTrackingCompletionListenerForFetchPhase(
-            SearchContext searchContext, long fetchStartTime, long fetchTime, String operation, boolean isFailed) {
+            SearchContext searchContext,
+            long fetchStartTime,
+            long fetchTime,
+            String operation,
+            boolean isFailed) {
         long overallStartTime = fetchStartTime;
         long queryTaskId = threadLocal.get().getOrDefault(QUERY_TASK_ID, 0l);
         /**
@@ -267,13 +271,11 @@ public class RTFPerformanceAnalyzerSearchListener
                  * overall start time.
                  */
                 long totalTime = System.nanoTime() - overallStartTime;
-                double operationShareFactor =
-                        computeShareFactor(
-                                totalOperationTime, totalTime);
+                double operationShareFactor = computeShareFactor(totalOperationTime, totalTime);
                 cpuUtilizationHistogram.record(
                         Utils.calculateCPUUtilization(
                                 numProcessors,
-                                totalOperationTime,
+                                totalTime,
                                 task.getTotalResourceStats().getCpuTimeInNanos(),
                                 operationShareFactor),
                         createTags());

--- a/src/main/java/org/opensearch/performanceanalyzer/listener/RTFPerformanceAnalyzerSearchListener.java
+++ b/src/main/java/org/opensearch/performanceanalyzer/listener/RTFPerformanceAnalyzerSearchListener.java
@@ -1,0 +1,255 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.performanceanalyzer.listener;
+
+import static org.opensearch.performanceanalyzer.commons.stats.metrics.StatExceptionCode.OPENSEARCH_REQUEST_INTERCEPTOR_ERROR;
+
+import com.google.common.annotations.VisibleForTesting;
+import java.util.HashMap;
+import java.util.Map;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.opensearch.core.action.NotifyOnceListener;
+import org.opensearch.index.shard.SearchOperationListener;
+import org.opensearch.performanceanalyzer.OpenSearchResources;
+import org.opensearch.performanceanalyzer.commons.collectors.StatsCollector;
+import org.opensearch.performanceanalyzer.commons.metrics.RTFMetrics;
+import org.opensearch.performanceanalyzer.commons.util.Util;
+import org.opensearch.performanceanalyzer.config.PerformanceAnalyzerController;
+import org.opensearch.performanceanalyzer.util.Utils;
+import org.opensearch.search.internal.SearchContext;
+import org.opensearch.tasks.Task;
+import org.opensearch.telemetry.metrics.Histogram;
+import org.opensearch.telemetry.metrics.MetricsRegistry;
+import org.opensearch.telemetry.metrics.tags.Tags;
+
+/**
+ * {@link SearchOperationListener} to capture the resource utilization of a shard search operation.
+ * This will be getting the resource tracking information from the {@link
+ * org.opensearch.tasks.TaskResourceTrackingService}.
+ */
+public class RTFPerformanceAnalyzerSearchListener
+        implements SearchOperationListener, SearchListener {
+
+    private static final Logger LOG =
+            LogManager.getLogger(RTFPerformanceAnalyzerSearchListener.class);
+    private static final String OPERATION_SHARD_FETCH = "shard_fetch";
+    private static final String OPERATION_SHARD_QUERY = "shard_query";
+    public static final String QUERY_START_TIME = "query_start_time";
+    public static final String FETCH_START_TIME = "fetch_start_time";
+    private final ThreadLocal<Map<String, Long>> threadLocal;
+    private static final SearchListener NO_OP_SEARCH_LISTENER = new NoOpSearchListener();
+
+    private final PerformanceAnalyzerController controller;
+    private final Histogram cpuUtilizationHistogram;
+    private final Histogram heapUsedHistogram;
+    private final int numProcessors;
+
+    public RTFPerformanceAnalyzerSearchListener(final PerformanceAnalyzerController controller) {
+        this.controller = controller;
+        this.cpuUtilizationHistogram = createCPUUtilizationHistogram();
+        heapUsedHistogram = createHeapUsedHistogram();
+        this.threadLocal = ThreadLocal.withInitial(() -> new HashMap<String, Long>());
+        this.numProcessors = Runtime.getRuntime().availableProcessors();
+    }
+
+    private Histogram createCPUUtilizationHistogram() {
+        MetricsRegistry metricsRegistry = OpenSearchResources.INSTANCE.getMetricsRegistry();
+        if (metricsRegistry != null) {
+            return metricsRegistry.createHistogram(
+                    RTFMetrics.OSMetrics.CPU_UTILIZATION.toString(),
+                    "CPU Utilization per shard for an operation",
+                    RTFMetrics.MetricUnits.RATE.toString());
+        } else {
+            LOG.debug("MetricsRegistry is null");
+            return null;
+        }
+    }
+
+    private Histogram createHeapUsedHistogram() {
+        MetricsRegistry metricsRegistry = OpenSearchResources.INSTANCE.getMetricsRegistry();
+        if (metricsRegistry != null) {
+            return metricsRegistry.createHistogram(
+                    RTFMetrics.HeapValue.HEAP_USED.toString(),
+                    "Heap used per shard for an operation",
+                    RTFMetrics.MetricUnits.BYTE.toString());
+        } else {
+            LOG.debug("MetricsRegistry is null");
+            return null;
+        }
+    }
+
+    @Override
+    public String toString() {
+        return RTFPerformanceAnalyzerSearchListener.class.getSimpleName();
+    }
+
+    @VisibleForTesting
+    SearchListener getSearchListener() {
+        return isSearchListenerEnabled() ? this : NO_OP_SEARCH_LISTENER;
+    }
+
+    private boolean isSearchListenerEnabled() {
+        LOG.debug(
+                "Controller enable status {}, CollectorMode value {}",
+                controller.isPerformanceAnalyzerEnabled(),
+                controller.getCollectorsSettingValue());
+        return OpenSearchResources.INSTANCE.getMetricsRegistry() != null
+                && controller.isPerformanceAnalyzerEnabled()
+                && (controller.getCollectorsSettingValue() == Util.CollectorMode.DUAL.getValue()
+                        || controller.getCollectorsSettingValue()
+                                == Util.CollectorMode.TELEMETRY.getValue());
+    }
+
+    @Override
+    public void onPreQueryPhase(SearchContext searchContext) {
+        try {
+            getSearchListener().preQueryPhase(searchContext);
+        } catch (Exception ex) {
+            LOG.error(ex);
+            StatsCollector.instance().logException(OPENSEARCH_REQUEST_INTERCEPTOR_ERROR);
+        }
+    }
+
+    @Override
+    public void onQueryPhase(SearchContext searchContext, long tookInNanos) {
+        try {
+            getSearchListener().queryPhase(searchContext, tookInNanos);
+        } catch (Exception ex) {
+            LOG.error(ex);
+            StatsCollector.instance().logException(OPENSEARCH_REQUEST_INTERCEPTOR_ERROR);
+        }
+    }
+
+    @Override
+    public void onFailedQueryPhase(SearchContext searchContext) {
+        try {
+            getSearchListener().failedQueryPhase(searchContext);
+        } catch (Exception ex) {
+            LOG.error(ex);
+            StatsCollector.instance().logException(OPENSEARCH_REQUEST_INTERCEPTOR_ERROR);
+        }
+    }
+
+    @Override
+    public void onPreFetchPhase(SearchContext searchContext) {
+        try {
+            getSearchListener().preFetchPhase(searchContext);
+        } catch (Exception ex) {
+            LOG.error(ex);
+            StatsCollector.instance().logException(OPENSEARCH_REQUEST_INTERCEPTOR_ERROR);
+        }
+    }
+
+    @Override
+    public void onFetchPhase(SearchContext searchContext, long tookInNanos) {
+        try {
+            getSearchListener().fetchPhase(searchContext, tookInNanos);
+        } catch (Exception ex) {
+            LOG.error(ex);
+            StatsCollector.instance().logException(OPENSEARCH_REQUEST_INTERCEPTOR_ERROR);
+        }
+    }
+
+    @Override
+    public void onFailedFetchPhase(SearchContext searchContext) {
+        try {
+            getSearchListener().failedFetchPhase(searchContext);
+        } catch (Exception ex) {
+            LOG.error(ex);
+            StatsCollector.instance().logException(OPENSEARCH_REQUEST_INTERCEPTOR_ERROR);
+        }
+    }
+
+    @Override
+    public void preQueryPhase(SearchContext searchContext) {
+        threadLocal.get().put(QUERY_START_TIME, System.nanoTime());
+    }
+
+    @Override
+    public void queryPhase(SearchContext searchContext, long tookInNanos) {
+        long queryStartTime = threadLocal.get().getOrDefault(QUERY_START_TIME, 0l);
+        addResourceTrackingCompletionListener(
+                searchContext, queryStartTime, OPERATION_SHARD_QUERY, false);
+    }
+
+    @Override
+    public void failedQueryPhase(SearchContext searchContext) {
+        long queryStartTime = threadLocal.get().getOrDefault(QUERY_START_TIME, 0l);
+        addResourceTrackingCompletionListener(
+                searchContext, queryStartTime, OPERATION_SHARD_QUERY, true);
+    }
+
+    @Override
+    public void preFetchPhase(SearchContext searchContext) {
+        threadLocal.get().put(FETCH_START_TIME, System.nanoTime());
+    }
+
+    @Override
+    public void fetchPhase(SearchContext searchContext, long tookInNanos) {
+        long fetchStartTime = threadLocal.get().getOrDefault(FETCH_START_TIME, 0l);
+        addResourceTrackingCompletionListener(
+                searchContext, fetchStartTime, OPERATION_SHARD_FETCH, false);
+    }
+
+    @Override
+    public void failedFetchPhase(SearchContext searchContext) {
+        long fetchStartTime = threadLocal.get().getOrDefault(FETCH_START_TIME, 0l);
+        addResourceTrackingCompletionListener(
+                searchContext, fetchStartTime, OPERATION_SHARD_FETCH, true);
+    }
+
+    private void addResourceTrackingCompletionListener(
+            SearchContext searchContext, long startTime, String operation, boolean isFailed) {
+        searchContext
+                .getTask()
+                .addResourceTrackingCompletionListener(
+                        createListener(
+                                searchContext,
+                                (System.nanoTime() - startTime),
+                                operation,
+                                isFailed));
+    }
+
+    @VisibleForTesting
+    NotifyOnceListener<Task> createListener(
+            SearchContext searchContext, long totalTime, String operation, boolean isFailed) {
+        return new NotifyOnceListener<Task>() {
+            @Override
+            protected void innerOnResponse(Task task) {
+                LOG.debug("Updating the counter for task {}", task.getId());
+                cpuUtilizationHistogram.record(
+                        Utils.calculateCPUUtilization(
+                                numProcessors,
+                                totalTime,
+                                task.getTotalResourceStats().getCpuTimeInNanos()),
+                        createTags());
+                heapUsedHistogram.record(
+                        Math.max(0, task.getTotalResourceStats().getMemoryInBytes()), createTags());
+            }
+
+            private Tags createTags() {
+                return Tags.create()
+                        .addTag(
+                                RTFMetrics.CommonDimension.INDEX_NAME.toString(),
+                                searchContext.request().shardId().getIndex().getName())
+                        .addTag(
+                                RTFMetrics.CommonDimension.INDEX_UUID.toString(),
+                                searchContext.request().shardId().getIndex().getUUID())
+                        .addTag(
+                                RTFMetrics.CommonDimension.SHARD_ID.toString(),
+                                searchContext.request().shardId().getId())
+                        .addTag(RTFMetrics.CommonDimension.OPERATION.toString(), operation)
+                        .addTag(RTFMetrics.CommonDimension.FAILED.toString(), isFailed);
+            }
+
+            @Override
+            protected void innerOnFailure(Exception e) {
+                LOG.error("Error is executing the the listener", e);
+            }
+        };
+    }
+}

--- a/src/main/java/org/opensearch/performanceanalyzer/transport/PerformanceAnalyzerTransportRequestHandler.java
+++ b/src/main/java/org/opensearch/performanceanalyzer/transport/PerformanceAnalyzerTransportRequestHandler.java
@@ -59,8 +59,8 @@ public class PerformanceAnalyzerTransportRequestHandler<T extends TransportReque
 
     private boolean isCollectorEnabled() {
         return controller.isPerformanceAnalyzerEnabled()
-                && (controller.getCollectorsSettingValue() == Util.CollectorMode.DUAL.getValue()
-                        || controller.getCollectorsSettingValue()
+                && (controller.getCollectorsRunModeValue() == Util.CollectorMode.DUAL.getValue()
+                        || controller.getCollectorsRunModeValue()
                                 == Util.CollectorMode.RCA.getValue());
     }
 

--- a/src/main/java/org/opensearch/performanceanalyzer/transport/RTFPerformanceAnalyzerTransportChannel.java
+++ b/src/main/java/org/opensearch/performanceanalyzer/transport/RTFPerformanceAnalyzerTransportChannel.java
@@ -98,7 +98,7 @@ public final class RTFPerformanceAnalyzerTransportChannel implements TransportCh
         long totalCpuTime =
                 Math.max(0, (threadMXBean.getThreadCpuTime(threadID) - phaseCPUStartTime));
         return Utils.calculateCPUUtilization(
-                numProcessors, (System.nanoTime() - phaseStartTime), totalCpuTime);
+                numProcessors, (System.nanoTime() - phaseStartTime), totalCpuTime, 1.0);
     }
 
     @VisibleForTesting

--- a/src/main/java/org/opensearch/performanceanalyzer/transport/RTFPerformanceAnalyzerTransportChannel.java
+++ b/src/main/java/org/opensearch/performanceanalyzer/transport/RTFPerformanceAnalyzerTransportChannel.java
@@ -77,20 +77,19 @@ public final class RTFPerformanceAnalyzerTransportChannel implements TransportCh
 
     @Override
     public void sendResponse(TransportResponse response) throws IOException {
-        emitMetrics(null);
+        emitMetrics(false);
         original.sendResponse(response);
     }
 
     @Override
     public void sendResponse(Exception exception) throws IOException {
-        emitMetrics(exception);
+        emitMetrics(true);
         original.sendResponse(exception);
     }
 
-    private void emitMetrics(Exception exception) {
+    private void emitMetrics(boolean isFailed) {
         double cpuUtilization = calculateCPUUtilization(operationStartTime, cpuStartTime);
-        recordCPUUtilizationMetric(
-                shardId, cpuUtilization, OPERATION_SHARD_BULK, exception != null);
+        recordCPUUtilizationMetric(shardId, cpuUtilization, OPERATION_SHARD_BULK, isFailed);
     }
 
     private double calculateCPUUtilization(long phaseStartTime, long phaseCPUStartTime) {

--- a/src/main/java/org/opensearch/performanceanalyzer/transport/RTFPerformanceAnalyzerTransportChannel.java
+++ b/src/main/java/org/opensearch/performanceanalyzer/transport/RTFPerformanceAnalyzerTransportChannel.java
@@ -1,0 +1,129 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.performanceanalyzer.transport;
+
+import com.google.common.annotations.VisibleForTesting;
+import com.sun.management.ThreadMXBean;
+import java.io.IOException;
+import java.lang.management.ManagementFactory;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.opensearch.core.index.shard.ShardId;
+import org.opensearch.core.transport.TransportResponse;
+import org.opensearch.performanceanalyzer.commons.metrics.RTFMetrics;
+import org.opensearch.performanceanalyzer.util.Utils;
+import org.opensearch.telemetry.metrics.Histogram;
+import org.opensearch.telemetry.metrics.tags.Tags;
+import org.opensearch.transport.TransportChannel;
+
+/**
+ * {@link TransportChannel} implementation to override the sendResponse behavior to have handle of
+ * the {@link org.opensearch.action.bulk.BulkShardRequest} completion.
+ */
+public final class RTFPerformanceAnalyzerTransportChannel implements TransportChannel {
+    private static final Logger LOG =
+            LogManager.getLogger(RTFPerformanceAnalyzerTransportChannel.class);
+
+    private static final ThreadMXBean threadMXBean =
+            (ThreadMXBean) ManagementFactory.getThreadMXBean();
+    private static final String OPERATION_SHARD_BULK = "shardbulk";
+    private static final String SHARD_ROLE_PRIMARY = "primary";
+    private static final String SHARD_ROLE_REPLICA = "replica";
+
+    private long cpuStartTime;
+    private long operationStartTime;
+
+    private Histogram cpuUtilizationHistogram;
+
+    private TransportChannel original;
+    private String indexName;
+    private ShardId shardId;
+    private boolean primary;
+
+    private long threadID;
+    private int numProcessors;
+
+    void set(
+            TransportChannel original,
+            Histogram cpuUtilizationHistogram,
+            String indexName,
+            ShardId shardId,
+            boolean bPrimary) {
+        this.original = original;
+        this.cpuUtilizationHistogram = cpuUtilizationHistogram;
+        this.indexName = indexName;
+        this.shardId = shardId;
+        this.primary = bPrimary;
+
+        this.operationStartTime = System.nanoTime();
+        threadID = Thread.currentThread().getId();
+        this.cpuStartTime = threadMXBean.getThreadCpuTime(threadID);
+        this.numProcessors = Runtime.getRuntime().availableProcessors();
+        LOG.debug("Thread Name {}", Thread.currentThread().getName());
+    }
+
+    @Override
+    public String getProfileName() {
+        return "RTFPerformanceAnalyzerTransportChannelProfile";
+    }
+
+    @Override
+    public String getChannelType() {
+        return "RTFPerformanceAnalyzerTransportChannelType";
+    }
+
+    @Override
+    public void sendResponse(TransportResponse response) throws IOException {
+        emitMetrics(null);
+        original.sendResponse(response);
+    }
+
+    @Override
+    public void sendResponse(Exception exception) throws IOException {
+        emitMetrics(exception);
+        original.sendResponse(exception);
+    }
+
+    private void emitMetrics(Exception exception) {
+        double cpuUtilization = calculateCPUUtilization(operationStartTime, cpuStartTime);
+        recordCPUUtilizationMetric(
+                shardId, cpuUtilization, OPERATION_SHARD_BULK, exception != null);
+    }
+
+    private double calculateCPUUtilization(long phaseStartTime, long phaseCPUStartTime) {
+        LOG.debug("Completion Thread Name {}", Thread.currentThread().getName());
+        long totalCpuTime =
+                Math.max(0, (threadMXBean.getThreadCpuTime(threadID) - phaseCPUStartTime));
+        return Utils.calculateCPUUtilization(
+                numProcessors, (System.nanoTime() - phaseStartTime), totalCpuTime);
+    }
+
+    @VisibleForTesting
+    void recordCPUUtilizationMetric(
+            ShardId shardId, double cpuUtilization, String operation, boolean isFailed) {
+        cpuUtilizationHistogram.record(
+                cpuUtilization,
+                Tags.create()
+                        .addTag(
+                                RTFMetrics.CommonDimension.INDEX_NAME.toString(),
+                                shardId.getIndex().getName())
+                        .addTag(
+                                RTFMetrics.CommonDimension.INDEX_UUID.toString(),
+                                shardId.getIndex().getUUID())
+                        .addTag(RTFMetrics.CommonDimension.SHARD_ID.toString(), shardId.getId())
+                        .addTag(RTFMetrics.CommonDimension.OPERATION.toString(), operation)
+                        .addTag(RTFMetrics.CommonDimension.FAILED.toString(), isFailed)
+                        .addTag(
+                                RTFMetrics.CommonDimension.SHARD_ROLE.toString(),
+                                primary ? SHARD_ROLE_PRIMARY : SHARD_ROLE_REPLICA));
+    }
+
+    // This function is called from the security plugin using reflection. Do not
+    // remove this function without changing the security plugin.
+    public TransportChannel getInnerChannel() {
+        return this.original;
+    }
+}

--- a/src/main/java/org/opensearch/performanceanalyzer/transport/RTFPerformanceAnalyzerTransportInterceptor.java
+++ b/src/main/java/org/opensearch/performanceanalyzer/transport/RTFPerformanceAnalyzerTransportInterceptor.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.performanceanalyzer.transport;
+
+import org.opensearch.performanceanalyzer.config.PerformanceAnalyzerController;
+import org.opensearch.transport.TransportInterceptor;
+import org.opensearch.transport.TransportRequest;
+import org.opensearch.transport.TransportRequestHandler;
+
+/**
+ * Transport Interceptor to intercept the Indexing requests and populate the resource utilization
+ * metrics.
+ */
+public final class RTFPerformanceAnalyzerTransportInterceptor implements TransportInterceptor {
+
+    private final PerformanceAnalyzerController controller;
+
+    public RTFPerformanceAnalyzerTransportInterceptor(
+            final PerformanceAnalyzerController controller) {
+        this.controller = controller;
+    }
+
+    @Override
+    public <T extends TransportRequest> TransportRequestHandler<T> interceptHandler(
+            String action,
+            String executor,
+            boolean forceExecution,
+            TransportRequestHandler<T> actualHandler) {
+        return new RTFPerformanceAnalyzerTransportRequestHandler<>(actualHandler, controller);
+    }
+}

--- a/src/main/java/org/opensearch/performanceanalyzer/transport/RTFPerformanceAnalyzerTransportRequestHandler.java
+++ b/src/main/java/org/opensearch/performanceanalyzer/transport/RTFPerformanceAnalyzerTransportRequestHandler.java
@@ -36,7 +36,7 @@ public final class RTFPerformanceAnalyzerTransportRequestHandler<T extends Trans
             LogManager.getLogger(RTFPerformanceAnalyzerTransportRequestHandler.class);
     private final PerformanceAnalyzerController controller;
     private TransportRequestHandler<T> actualHandler;
-    boolean logOnce = false;
+    private boolean logOnce = false;
     private final Histogram cpuUtilizationHistogram;
 
     RTFPerformanceAnalyzerTransportRequestHandler(
@@ -52,7 +52,7 @@ public final class RTFPerformanceAnalyzerTransportRequestHandler<T extends Trans
             return metricsRegistry.createHistogram(
                     RTFMetrics.OSMetrics.CPU_UTILIZATION.toString(),
                     "CPU Utilization per shard for an operation",
-                    "rate");
+                    RTFMetrics.MetricUnits.RATE.toString());
         } else {
             return null;
         }
@@ -79,8 +79,8 @@ public final class RTFPerformanceAnalyzerTransportRequestHandler<T extends Trans
     private boolean isCollectorEnabled() {
         return OpenSearchResources.INSTANCE.getMetricsRegistry() != null
                 && controller.isPerformanceAnalyzerEnabled()
-                && (controller.getCollectorsSettingValue() == Util.CollectorMode.DUAL.getValue()
-                        || controller.getCollectorsSettingValue()
+                && (controller.getCollectorsRunModeValue() == Util.CollectorMode.DUAL.getValue()
+                        || controller.getCollectorsRunModeValue()
                                 == Util.CollectorMode.TELEMETRY.getValue());
     }
 

--- a/src/main/java/org/opensearch/performanceanalyzer/transport/RTFPerformanceAnalyzerTransportRequestHandler.java
+++ b/src/main/java/org/opensearch/performanceanalyzer/transport/RTFPerformanceAnalyzerTransportRequestHandler.java
@@ -12,31 +12,50 @@ import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.opensearch.action.bulk.BulkShardRequest;
 import org.opensearch.action.support.replication.TransportReplicationAction.ConcreteShardRequest;
+import org.opensearch.performanceanalyzer.OpenSearchResources;
 import org.opensearch.performanceanalyzer.commons.collectors.StatsCollector;
+import org.opensearch.performanceanalyzer.commons.metrics.RTFMetrics;
 import org.opensearch.performanceanalyzer.commons.util.Util;
 import org.opensearch.performanceanalyzer.config.PerformanceAnalyzerController;
 import org.opensearch.tasks.Task;
+import org.opensearch.telemetry.metrics.Histogram;
+import org.opensearch.telemetry.metrics.MetricsRegistry;
 import org.opensearch.transport.TransportChannel;
 import org.opensearch.transport.TransportRequest;
 import org.opensearch.transport.TransportRequestHandler;
 
-public class PerformanceAnalyzerTransportRequestHandler<T extends TransportRequest>
+/**
+ * {@link TransportRequestHandler} implementation to intercept only the {@link BulkShardRequest} and
+ * skip other transport calls.
+ *
+ * @param <T> {@link TransportRequest}
+ */
+public final class RTFPerformanceAnalyzerTransportRequestHandler<T extends TransportRequest>
         implements TransportRequestHandler<T> {
     private static final Logger LOG =
-            LogManager.getLogger(PerformanceAnalyzerTransportRequestHandler.class);
+            LogManager.getLogger(RTFPerformanceAnalyzerTransportRequestHandler.class);
     private final PerformanceAnalyzerController controller;
     private TransportRequestHandler<T> actualHandler;
     boolean logOnce = false;
+    private final Histogram cpuUtilizationHistogram;
 
-    PerformanceAnalyzerTransportRequestHandler(
+    RTFPerformanceAnalyzerTransportRequestHandler(
             TransportRequestHandler<T> actualHandler, PerformanceAnalyzerController controller) {
         this.actualHandler = actualHandler;
         this.controller = controller;
+        this.cpuUtilizationHistogram = createCPUUtilizationHistogram();
     }
 
-    PerformanceAnalyzerTransportRequestHandler<T> set(TransportRequestHandler<T> actualHandler) {
-        this.actualHandler = actualHandler;
-        return this;
+    private Histogram createCPUUtilizationHistogram() {
+        MetricsRegistry metricsRegistry = OpenSearchResources.INSTANCE.getMetricsRegistry();
+        if (metricsRegistry != null) {
+            return metricsRegistry.createHistogram(
+                    RTFMetrics.OSMetrics.CPU_UTILIZATION.toString(),
+                    "CPU Utilization per shard for an operation",
+                    "rate");
+        } else {
+            return null;
+        }
     }
 
     @Override
@@ -58,10 +77,11 @@ public class PerformanceAnalyzerTransportRequestHandler<T extends TransportReque
     }
 
     private boolean isCollectorEnabled() {
-        return controller.isPerformanceAnalyzerEnabled()
+        return OpenSearchResources.INSTANCE.getMetricsRegistry() != null
+                && controller.isPerformanceAnalyzerEnabled()
                 && (controller.getCollectorsSettingValue() == Util.CollectorMode.DUAL.getValue()
                         || controller.getCollectorsSettingValue()
-                                == Util.CollectorMode.RCA.getValue());
+                                == Util.CollectorMode.TELEMETRY.getValue());
     }
 
     private TransportChannel getShardBulkChannel(T request, TransportChannel channel, Task task) {
@@ -85,17 +105,12 @@ public class PerformanceAnalyzerTransportRequestHandler<T extends TransportReque
         }
 
         BulkShardRequest bsr = (BulkShardRequest) transportRequest;
-        PerformanceAnalyzerTransportChannel performanceanalyzerChannel =
-                new PerformanceAnalyzerTransportChannel();
+        RTFPerformanceAnalyzerTransportChannel rtfPerformanceAnalyzerTransportChannel =
+                new RTFPerformanceAnalyzerTransportChannel();
 
         try {
-            performanceanalyzerChannel.set(
-                    channel,
-                    System.currentTimeMillis(),
-                    bsr.index(),
-                    bsr.shardId().id(),
-                    bsr.items().length,
-                    bPrimary);
+            rtfPerformanceAnalyzerTransportChannel.set(
+                    channel, cpuUtilizationHistogram, bsr.index(), bsr.shardId(), bPrimary);
         } catch (Exception ex) {
             if (!logOnce) {
                 LOG.error(ex);
@@ -104,6 +119,6 @@ public class PerformanceAnalyzerTransportRequestHandler<T extends TransportReque
             StatsCollector.instance().logException(OPENSEARCH_REQUEST_INTERCEPTOR_ERROR);
         }
 
-        return performanceanalyzerChannel;
+        return rtfPerformanceAnalyzerTransportChannel;
     }
 }

--- a/src/main/java/org/opensearch/performanceanalyzer/util/Utils.java
+++ b/src/main/java/org/opensearch/performanceanalyzer/util/Utils.java
@@ -114,14 +114,16 @@ public class Utils {
 
     public static double calculateCPUUtilization(
             int numProcessors, long totalOperationTime, long cpuUsageTime, double cpuShareFactor) {
-        LOG.debug("numProcessors {}", numProcessors);
-        LOG.debug("cpuShareFactor {}", cpuShareFactor);
-        LOG.debug("totalCpuTime {}", cpuUsageTime);
-        LOG.debug("totalOperationTime {}", totalOperationTime);
+        LOG.debug("CPUUtilization calculation - numProcessors {}", numProcessors);
+        LOG.debug("CPUUtilization calculation - cpuShareFactor {}", cpuShareFactor);
+        LOG.debug("CPUUtilization calculation - totalCpuTime {}", cpuUsageTime);
+        LOG.debug("CPUUtilization calculation - totalOperationTime {}", totalOperationTime);
         if (totalOperationTime == 0l || cpuUsageTime == 0l || numProcessors == 0) {
             return 0.0d;
         }
         double totalAvailableCPUTime = Double.valueOf(totalOperationTime * numProcessors);
-        return cpuShareFactor * (cpuUsageTime / totalAvailableCPUTime);
+        double cpuUtil = cpuShareFactor * (cpuUsageTime / totalAvailableCPUTime);
+        LOG.debug("CPUUtilization calculation - cpuUtil {}", cpuUtil);
+        return cpuUtil;
     }
 }

--- a/src/main/java/org/opensearch/performanceanalyzer/util/Utils.java
+++ b/src/main/java/org/opensearch/performanceanalyzer/util/Utils.java
@@ -8,6 +8,8 @@ package org.opensearch.performanceanalyzer.util;
 import java.util.EnumSet;
 import java.util.HashMap;
 import java.util.Iterator;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 import org.opensearch.action.admin.indices.stats.CommonStats;
 import org.opensearch.action.admin.indices.stats.CommonStatsFlags;
 import org.opensearch.action.admin.indices.stats.IndexShardStats;
@@ -27,6 +29,7 @@ import org.opensearch.performanceanalyzer.commons.metrics.MetricsConfiguration;
 import org.opensearch.performanceanalyzer.commons.stats.ServiceMetrics;
 
 public class Utils {
+    private static final Logger LOG = LogManager.getLogger(Utils.class);
 
     public static void configureMetrics() {
         ServiceMetrics.initStatsReporter();
@@ -108,4 +111,16 @@ public class Utils {
                     IndexShardState.RECOVERING,
                     IndexShardState.POST_RECOVERY,
                     IndexShardState.STARTED);
+
+    public static double calculateCPUUtilization(
+            int numProcessors, long totalOperationTime, long cpuUsageTime) {
+        LOG.debug("totalCpuTime {}", cpuUsageTime);
+        LOG.debug("totalOperationTime {}", totalOperationTime);
+        LOG.debug("numProcessors {}", numProcessors);
+        if (totalOperationTime == 0l || cpuUsageTime == 0l || numProcessors == 0) {
+            return 0.0d;
+        }
+        double totalAvailableCPUTime = Double.valueOf(totalOperationTime * numProcessors);
+        return cpuUsageTime / totalAvailableCPUTime;
+    }
 }

--- a/src/main/java/org/opensearch/performanceanalyzer/util/Utils.java
+++ b/src/main/java/org/opensearch/performanceanalyzer/util/Utils.java
@@ -112,18 +112,37 @@ public class Utils {
                     IndexShardState.POST_RECOVERY,
                     IndexShardState.STARTED);
 
+    /**
+     * CPU Utilization is the time spend in CPU cycles divide by the total time cpu available time.
+     * Total cpu available time would be the multiplication of num of processors and the process
+     * time. It also takes into account the cpuShareFactor in case some adjustments are needed.
+     *
+     * @param numProcessors
+     * @param totalOperationTime
+     * @param cpuUsageTime
+     * @param cpuShareFactor
+     * @return
+     */
     public static double calculateCPUUtilization(
             int numProcessors, long totalOperationTime, long cpuUsageTime, double cpuShareFactor) {
-        LOG.debug("CPUUtilization calculation - numProcessors {}", numProcessors);
-        LOG.debug("CPUUtilization calculation - cpuShareFactor {}", cpuShareFactor);
-        LOG.debug("CPUUtilization calculation - totalCpuTime {}", cpuUsageTime);
-        LOG.debug("CPUUtilization calculation - totalOperationTime {}", totalOperationTime);
+        LOG.debug(
+                "Performance Analyzer CPUUtilization calculation with numProcessors: {}",
+                numProcessors);
+        LOG.debug(
+                "Performance Analyzer CPUUtilization calculation with cpuShareFactor {}",
+                cpuShareFactor);
+        LOG.debug(
+                "Performance Analyzer CPUUtilization calculation with totalCpuTime {}",
+                cpuUsageTime);
+        LOG.debug(
+                "Performance Analyzer CPUUtilization calculation with totalOperationTime {}",
+                totalOperationTime);
         if (totalOperationTime == 0l || cpuUsageTime == 0l || numProcessors == 0) {
             return 0.0d;
         }
         double totalAvailableCPUTime = Double.valueOf(totalOperationTime * numProcessors);
         double cpuUtil = cpuShareFactor * (cpuUsageTime / totalAvailableCPUTime);
-        LOG.debug("CPUUtilization calculation - cpuUtil {}", cpuUtil);
+        LOG.debug("Performance Analyzer CPUUtilization calculation with cpuUtil {}", cpuUtil);
         return cpuUtil;
     }
 }

--- a/src/main/java/org/opensearch/performanceanalyzer/util/Utils.java
+++ b/src/main/java/org/opensearch/performanceanalyzer/util/Utils.java
@@ -113,14 +113,15 @@ public class Utils {
                     IndexShardState.STARTED);
 
     public static double calculateCPUUtilization(
-            int numProcessors, long totalOperationTime, long cpuUsageTime) {
+            int numProcessors, long totalOperationTime, long cpuUsageTime, double cpuShareFactor) {
+        LOG.debug("numProcessors {}", numProcessors);
+        LOG.debug("cpuShareFactor {}", cpuShareFactor);
         LOG.debug("totalCpuTime {}", cpuUsageTime);
         LOG.debug("totalOperationTime {}", totalOperationTime);
-        LOG.debug("numProcessors {}", numProcessors);
         if (totalOperationTime == 0l || cpuUsageTime == 0l || numProcessors == 0) {
             return 0.0d;
         }
         double totalAvailableCPUTime = Double.valueOf(totalOperationTime * numProcessors);
-        return cpuUsageTime / totalAvailableCPUTime;
+        return cpuShareFactor * (cpuUsageTime / totalAvailableCPUTime);
     }
 }

--- a/src/test/java/org/opensearch/performanceanalyzer/PerformanceAnalyzerPluginTests.java
+++ b/src/test/java/org/opensearch/performanceanalyzer/PerformanceAnalyzerPluginTests.java
@@ -22,7 +22,6 @@ import org.junit.Test;
 import org.opensearch.action.ActionRequest;
 import org.opensearch.action.support.ActionFilter;
 import org.opensearch.client.node.NodeClient;
-import org.opensearch.cluster.ClusterManagerMetrics;
 import org.opensearch.cluster.service.ClusterService;
 import org.opensearch.common.settings.ClusterSettings;
 import org.opensearch.common.settings.Setting;
@@ -90,12 +89,7 @@ public class PerformanceAnalyzerPluginTests extends OpenSearchTestCase {
         } catch (Exception e) {
             e.printStackTrace();
         }
-        clusterService =
-                new ClusterService(
-                        settings,
-                        clusterSettings,
-                        threadPool,
-                        new ClusterManagerMetrics(metricsRegistry));
+        clusterService = new ClusterService(settings, clusterSettings, threadPool);
         identityService = new IdentityService(Settings.EMPTY, List.of());
         restController =
                 new RestController(
@@ -131,7 +125,7 @@ public class PerformanceAnalyzerPluginTests extends OpenSearchTestCase {
     @Test
     public void testGetTransportInterceptors() {
         List<TransportInterceptor> list = plugin.getTransportInterceptors(null, null);
-        assertEquals(1, list.size());
+        assertEquals(2, list.size());
         assertEquals(PerformanceAnalyzerTransportInterceptor.class, list.get(0).getClass());
     }
 

--- a/src/test/java/org/opensearch/performanceanalyzer/listener/PerformanceAnalyzerSearchListenerTests.java
+++ b/src/test/java/org/opensearch/performanceanalyzer/listener/PerformanceAnalyzerSearchListenerTests.java
@@ -72,15 +72,15 @@ public class PerformanceAnalyzerSearchListenerTests {
 
     @Test
     public void tesSearchListener() {
-        Mockito.when(controller.getCollectorsSettingValue())
+        Mockito.when(controller.getCollectorsRunModeValue())
                 .thenReturn(Util.CollectorMode.TELEMETRY.getValue());
         assertTrue(searchListener.getSearchListener() instanceof NoOpSearchListener);
 
-        Mockito.when(controller.getCollectorsSettingValue())
+        Mockito.when(controller.getCollectorsRunModeValue())
                 .thenReturn(Util.CollectorMode.RCA.getValue());
         assertTrue(searchListener.getSearchListener() instanceof PerformanceAnalyzerSearchListener);
 
-        Mockito.when(controller.getCollectorsSettingValue())
+        Mockito.when(controller.getCollectorsRunModeValue())
                 .thenReturn(Util.CollectorMode.DUAL.getValue());
         assertTrue(searchListener.getSearchListener() instanceof PerformanceAnalyzerSearchListener);
     }

--- a/src/test/java/org/opensearch/performanceanalyzer/listener/PerformanceAnalyzerSearchListenerTests.java
+++ b/src/test/java/org/opensearch/performanceanalyzer/listener/PerformanceAnalyzerSearchListenerTests.java
@@ -25,6 +25,7 @@ import org.opensearch.performanceanalyzer.commons.metrics.AllMetrics;
 import org.opensearch.performanceanalyzer.commons.metrics.MetricsConfiguration;
 import org.opensearch.performanceanalyzer.commons.metrics.PerformanceAnalyzerMetrics;
 import org.opensearch.performanceanalyzer.commons.stats.metrics.StatExceptionCode;
+import org.opensearch.performanceanalyzer.commons.util.Util;
 import org.opensearch.performanceanalyzer.config.PerformanceAnalyzerController;
 import org.opensearch.performanceanalyzer.util.TestUtil;
 import org.opensearch.performanceanalyzer.util.Utils;
@@ -67,6 +68,21 @@ public class PerformanceAnalyzerSearchListenerTests {
 
         // clean metricQueue before running every test
         TestUtil.readEvents();
+    }
+
+    @Test
+    public void tesSearchListener() {
+        Mockito.when(controller.getCollectorsSettingValue())
+                .thenReturn(Util.CollectorMode.TELEMETRY.getValue());
+        assertTrue(searchListener.getSearchListener() instanceof NoOpSearchListener);
+
+        Mockito.when(controller.getCollectorsSettingValue())
+                .thenReturn(Util.CollectorMode.RCA.getValue());
+        assertTrue(searchListener.getSearchListener() instanceof PerformanceAnalyzerSearchListener);
+
+        Mockito.when(controller.getCollectorsSettingValue())
+                .thenReturn(Util.CollectorMode.DUAL.getValue());
+        assertTrue(searchListener.getSearchListener() instanceof PerformanceAnalyzerSearchListener);
     }
 
     @Test

--- a/src/test/java/org/opensearch/performanceanalyzer/listener/RTFPerformanceAnalyzerSearchListenerTests.java
+++ b/src/test/java/org/opensearch/performanceanalyzer/listener/RTFPerformanceAnalyzerSearchListenerTests.java
@@ -1,0 +1,163 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.performanceanalyzer.listener;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.MockitoAnnotations.initMocks;
+
+import org.apache.commons.lang3.SystemUtils;
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.opensearch.action.search.SearchShardTask;
+import org.opensearch.core.action.NotifyOnceListener;
+import org.opensearch.core.index.Index;
+import org.opensearch.core.index.shard.ShardId;
+import org.opensearch.core.tasks.resourcetracker.TaskResourceUsage;
+import org.opensearch.performanceanalyzer.OpenSearchResources;
+import org.opensearch.performanceanalyzer.commons.util.Util;
+import org.opensearch.performanceanalyzer.config.PerformanceAnalyzerController;
+import org.opensearch.search.internal.SearchContext;
+import org.opensearch.search.internal.ShardSearchRequest;
+import org.opensearch.tasks.Task;
+import org.opensearch.telemetry.metrics.Histogram;
+import org.opensearch.telemetry.metrics.MetricsRegistry;
+import org.opensearch.telemetry.metrics.tags.Tags;
+
+public class RTFPerformanceAnalyzerSearchListenerTests {
+
+    private RTFPerformanceAnalyzerSearchListener searchListener;
+
+    @Mock private SearchContext searchContext;
+    @Mock private ShardSearchRequest shardSearchRequest;
+    @Mock private ShardId shardId;
+    @Mock private PerformanceAnalyzerController controller;
+    @Mock private SearchShardTask task;
+    @Mock private MetricsRegistry metricsRegistry;
+    @Mock private Histogram cpuUtilizationHistogram;
+    @Mock private Histogram heapUsedHistogram;
+    @Mock private Index index;
+
+    @Mock private TaskResourceUsage taskResourceUsage;
+
+    @BeforeClass
+    public static void setup() {
+        // this test only runs in Linux system
+        // as some of the static members of the ThreadList class are specific to Linux
+        org.junit.Assume.assumeTrue(SystemUtils.IS_OS_LINUX);
+    }
+
+    @Before
+    public void init() {
+        initMocks(this);
+        OpenSearchResources.INSTANCE.setMetricsRegistry(metricsRegistry);
+        Mockito.when(controller.isPerformanceAnalyzerEnabled()).thenReturn(true);
+        Mockito.when(
+                        metricsRegistry.createHistogram(
+                                Mockito.eq("CPU_Utilization"),
+                                Mockito.anyString(),
+                                Mockito.eq("rate")))
+                .thenReturn(cpuUtilizationHistogram);
+        Mockito.when(
+                        metricsRegistry.createHistogram(
+                                Mockito.eq("heap_used"), Mockito.anyString(), Mockito.eq("B")))
+                .thenReturn(heapUsedHistogram);
+        searchListener = new RTFPerformanceAnalyzerSearchListener(controller);
+        assertEquals(
+                RTFPerformanceAnalyzerSearchListener.class.getSimpleName(),
+                searchListener.toString());
+    }
+
+    @Test
+    public void tesSearchListener() {
+        Mockito.when(controller.getCollectorsSettingValue())
+                .thenReturn(Util.CollectorMode.RCA.getValue());
+        assertTrue(searchListener.getSearchListener() instanceof NoOpSearchListener);
+
+        Mockito.when(controller.getCollectorsSettingValue())
+                .thenReturn(Util.CollectorMode.TELEMETRY.getValue());
+        assertTrue(
+                searchListener.getSearchListener() instanceof RTFPerformanceAnalyzerSearchListener);
+
+        Mockito.when(controller.getCollectorsSettingValue())
+                .thenReturn(Util.CollectorMode.DUAL.getValue());
+        assertTrue(
+                searchListener.getSearchListener() instanceof RTFPerformanceAnalyzerSearchListener);
+    }
+
+    @Test
+    public void testQueryPhase() {
+        initializeValidSearchContext(true);
+        Mockito.when(controller.getCollectorsSettingValue())
+                .thenReturn(Util.CollectorMode.TELEMETRY.getValue());
+        searchListener.preQueryPhase(searchContext);
+        searchListener.queryPhase(searchContext, 0l);
+        Mockito.verify(task).addResourceTrackingCompletionListener(Mockito.any());
+    }
+
+    @Test
+    public void testQueryPhaseFailed() {
+        initializeValidSearchContext(true);
+        Mockito.when(controller.getCollectorsSettingValue())
+                .thenReturn(Util.CollectorMode.TELEMETRY.getValue());
+        searchListener.preQueryPhase(searchContext);
+        searchListener.failedQueryPhase(searchContext);
+        Mockito.verify(task).addResourceTrackingCompletionListener(Mockito.any());
+    }
+
+    @Test
+    public void testFetchPhase() {
+        initializeValidSearchContext(true);
+        Mockito.when(controller.getCollectorsSettingValue())
+                .thenReturn(Util.CollectorMode.TELEMETRY.getValue());
+        searchListener.preFetchPhase(searchContext);
+        searchListener.fetchPhase(searchContext, 0l);
+        Mockito.verify(task).addResourceTrackingCompletionListener(Mockito.any());
+    }
+
+    @Test
+    public void testFetchPhaseFailed() {
+        initializeValidSearchContext(true);
+        Mockito.when(controller.getCollectorsSettingValue())
+                .thenReturn(Util.CollectorMode.TELEMETRY.getValue());
+        searchListener.preFetchPhase(searchContext);
+        searchListener.failedFetchPhase(searchContext);
+        Mockito.verify(task).addResourceTrackingCompletionListener(Mockito.any());
+    }
+
+    @Test
+    public void testTaskCompletionListener() {
+        initializeValidSearchContext(true);
+        RTFPerformanceAnalyzerSearchListener rtfSearchListener =
+                new RTFPerformanceAnalyzerSearchListener(controller);
+
+        Mockito.when(shardId.getIndex()).thenReturn(index);
+        Mockito.when(index.getName()).thenReturn("myTestIndex");
+        Mockito.when(index.getUUID()).thenReturn("abc-def");
+        Mockito.when(task.getTotalResourceStats()).thenReturn(taskResourceUsage);
+        Mockito.when(taskResourceUsage.getCpuTimeInNanos()).thenReturn(10l);
+
+        NotifyOnceListener<Task> taskCompletionListener =
+                rtfSearchListener.createListener(searchContext, 0l, "test", false);
+        taskCompletionListener.onResponse(task);
+        Mockito.verify(cpuUtilizationHistogram)
+                .record(Mockito.anyDouble(), Mockito.any(Tags.class));
+        Mockito.verify(heapUsedHistogram).record(Mockito.anyDouble(), Mockito.any(Tags.class));
+    }
+
+    private void initializeValidSearchContext(boolean isValid) {
+        if (isValid) {
+            Mockito.when(searchContext.request()).thenReturn(shardSearchRequest);
+            Mockito.when(searchContext.getTask()).thenReturn(task);
+            Mockito.when(shardSearchRequest.shardId()).thenReturn(shardId);
+        } else {
+            Mockito.when(searchContext.request()).thenReturn(null);
+        }
+    }
+}

--- a/src/test/java/org/opensearch/performanceanalyzer/listener/RTFPerformanceAnalyzerSearchListenerTests.java
+++ b/src/test/java/org/opensearch/performanceanalyzer/listener/RTFPerformanceAnalyzerSearchListenerTests.java
@@ -132,6 +132,18 @@ public class RTFPerformanceAnalyzerSearchListenerTests {
     }
 
     @Test
+    public void testOperationShareFactor() {
+        assertEquals(
+                Double.valueOf(10.0 / 15),
+                RTFPerformanceAnalyzerSearchListener.computeShareFactor(10, 15),
+                0);
+        assertEquals(
+                Double.valueOf(1),
+                RTFPerformanceAnalyzerSearchListener.computeShareFactor(15, 10),
+                0);
+    }
+
+    @Test
     public void testTaskCompletionListener() {
         initializeValidSearchContext(true);
         RTFPerformanceAnalyzerSearchListener rtfSearchListener =
@@ -144,7 +156,7 @@ public class RTFPerformanceAnalyzerSearchListenerTests {
         Mockito.when(taskResourceUsage.getCpuTimeInNanos()).thenReturn(10l);
 
         NotifyOnceListener<Task> taskCompletionListener =
-                rtfSearchListener.createListener(searchContext, 0l, "test", false);
+                rtfSearchListener.createListener(searchContext, 0l, 0l, "test", false);
         taskCompletionListener.onResponse(task);
         Mockito.verify(cpuUtilizationHistogram)
                 .record(Mockito.anyDouble(), Mockito.any(Tags.class));

--- a/src/test/java/org/opensearch/performanceanalyzer/listener/RTFPerformanceAnalyzerSearchListenerTests.java
+++ b/src/test/java/org/opensearch/performanceanalyzer/listener/RTFPerformanceAnalyzerSearchListenerTests.java
@@ -76,16 +76,16 @@ public class RTFPerformanceAnalyzerSearchListenerTests {
 
     @Test
     public void tesSearchListener() {
-        Mockito.when(controller.getCollectorsSettingValue())
+        Mockito.when(controller.getCollectorsRunModeValue())
                 .thenReturn(Util.CollectorMode.RCA.getValue());
         assertTrue(searchListener.getSearchListener() instanceof NoOpSearchListener);
 
-        Mockito.when(controller.getCollectorsSettingValue())
+        Mockito.when(controller.getCollectorsRunModeValue())
                 .thenReturn(Util.CollectorMode.TELEMETRY.getValue());
         assertTrue(
                 searchListener.getSearchListener() instanceof RTFPerformanceAnalyzerSearchListener);
 
-        Mockito.when(controller.getCollectorsSettingValue())
+        Mockito.when(controller.getCollectorsRunModeValue())
                 .thenReturn(Util.CollectorMode.DUAL.getValue());
         assertTrue(
                 searchListener.getSearchListener() instanceof RTFPerformanceAnalyzerSearchListener);
@@ -94,7 +94,7 @@ public class RTFPerformanceAnalyzerSearchListenerTests {
     @Test
     public void testQueryPhase() {
         initializeValidSearchContext(true);
-        Mockito.when(controller.getCollectorsSettingValue())
+        Mockito.when(controller.getCollectorsRunModeValue())
                 .thenReturn(Util.CollectorMode.TELEMETRY.getValue());
         searchListener.preQueryPhase(searchContext);
         searchListener.queryPhase(searchContext, 0l);
@@ -104,7 +104,7 @@ public class RTFPerformanceAnalyzerSearchListenerTests {
     @Test
     public void testQueryPhaseFailed() {
         initializeValidSearchContext(true);
-        Mockito.when(controller.getCollectorsSettingValue())
+        Mockito.when(controller.getCollectorsRunModeValue())
                 .thenReturn(Util.CollectorMode.TELEMETRY.getValue());
         searchListener.preQueryPhase(searchContext);
         searchListener.failedQueryPhase(searchContext);
@@ -114,7 +114,7 @@ public class RTFPerformanceAnalyzerSearchListenerTests {
     @Test
     public void testFetchPhase() {
         initializeValidSearchContext(true);
-        Mockito.when(controller.getCollectorsSettingValue())
+        Mockito.when(controller.getCollectorsRunModeValue())
                 .thenReturn(Util.CollectorMode.TELEMETRY.getValue());
         searchListener.preFetchPhase(searchContext);
         searchListener.fetchPhase(searchContext, 0l);
@@ -124,7 +124,7 @@ public class RTFPerformanceAnalyzerSearchListenerTests {
     @Test
     public void testFetchPhaseFailed() {
         initializeValidSearchContext(true);
-        Mockito.when(controller.getCollectorsSettingValue())
+        Mockito.when(controller.getCollectorsRunModeValue())
                 .thenReturn(Util.CollectorMode.TELEMETRY.getValue());
         searchListener.preFetchPhase(searchContext);
         searchListener.failedFetchPhase(searchContext);

--- a/src/test/java/org/opensearch/performanceanalyzer/listener/RTFPerformanceAnalyzerSearchListenerTests.java
+++ b/src/test/java/org/opensearch/performanceanalyzer/listener/RTFPerformanceAnalyzerSearchListenerTests.java
@@ -60,13 +60,13 @@ public class RTFPerformanceAnalyzerSearchListenerTests {
         Mockito.when(controller.isPerformanceAnalyzerEnabled()).thenReturn(true);
         Mockito.when(
                         metricsRegistry.createHistogram(
-                                Mockito.eq("CPU_Utilization"),
+                                Mockito.eq("cpu_utilization"),
                                 Mockito.anyString(),
                                 Mockito.eq("rate")))
                 .thenReturn(cpuUtilizationHistogram);
         Mockito.when(
                         metricsRegistry.createHistogram(
-                                Mockito.eq("heap_used"), Mockito.anyString(), Mockito.eq("B")))
+                                Mockito.eq("heap_allocated"), Mockito.anyString(), Mockito.eq("B")))
                 .thenReturn(heapUsedHistogram);
         searchListener = new RTFPerformanceAnalyzerSearchListener(controller);
         assertEquals(

--- a/src/test/java/org/opensearch/performanceanalyzer/transport/PerformanceAnalyzerTransportRequestHandlerTests.java
+++ b/src/test/java/org/opensearch/performanceanalyzer/transport/PerformanceAnalyzerTransportRequestHandlerTests.java
@@ -72,7 +72,7 @@ public class PerformanceAnalyzerTransportRequestHandlerTests {
 
     @Test
     public void testGetChannelIfRCAModeIsDisabled() {
-        Mockito.when(controller.getCollectorsSettingValue())
+        Mockito.when(controller.getCollectorsRunModeValue())
                 .thenReturn(Util.CollectorMode.TELEMETRY.getValue());
         concreteShardRequest = new ConcreteShardRequest(bulkShardRequest, "id", 1);
         handler.getChannel(concreteShardRequest, channel, task);
@@ -85,7 +85,7 @@ public class PerformanceAnalyzerTransportRequestHandlerTests {
 
     @Test
     public void testGetChannelIfDualModeIsEnabled() {
-        Mockito.when(controller.getCollectorsSettingValue())
+        Mockito.when(controller.getCollectorsRunModeValue())
                 .thenReturn(Util.CollectorMode.DUAL.getValue());
         concreteShardRequest = new ConcreteShardRequest(bulkShardRequest, "id", 1);
         handler.getChannel(concreteShardRequest, channel, task);

--- a/src/test/java/org/opensearch/performanceanalyzer/transport/RTFPerformanceAnalyzerTransportChannelTests.java
+++ b/src/test/java/org/opensearch/performanceanalyzer/transport/RTFPerformanceAnalyzerTransportChannelTests.java
@@ -1,0 +1,82 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.performanceanalyzer.transport;
+
+import static org.junit.Assert.assertEquals;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyDouble;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.MockitoAnnotations.initMocks;
+
+import java.io.IOException;
+import org.apache.commons.lang3.SystemUtils;
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.opensearch.core.index.Index;
+import org.opensearch.core.index.shard.ShardId;
+import org.opensearch.core.transport.TransportResponse;
+import org.opensearch.performanceanalyzer.util.Utils;
+import org.opensearch.telemetry.metrics.Histogram;
+import org.opensearch.telemetry.metrics.tags.Tags;
+import org.opensearch.transport.TransportChannel;
+
+public class RTFPerformanceAnalyzerTransportChannelTests {
+    private RTFPerformanceAnalyzerTransportChannel channel;
+
+    @Mock private TransportChannel originalChannel;
+    @Mock private TransportResponse response;
+    @Mock private Histogram cpuUtilizationHistogram;
+    private ShardId shardId;
+    @Mock private ShardId mockedShardId;
+    @Mock private Index index;
+
+    @Before
+    public void init() {
+        // this test only runs in Linux system
+        // as some of the static members of the ThreadList class are specific to Linux
+        org.junit.Assume.assumeTrue(SystemUtils.IS_OS_LINUX);
+        Utils.configureMetrics();
+        initMocks(this);
+        String indexName = "testIndex";
+        shardId = new ShardId(new Index(indexName, "uuid"), 1);
+        channel = new RTFPerformanceAnalyzerTransportChannel();
+        channel.set(originalChannel, cpuUtilizationHistogram, indexName, shardId, false);
+        assertEquals("RTFPerformanceAnalyzerTransportChannelProfile", channel.getProfileName());
+        assertEquals("RTFPerformanceAnalyzerTransportChannelType", channel.getChannelType());
+        assertEquals(originalChannel, channel.getInnerChannel());
+    }
+
+    @Test
+    public void testResponse() throws IOException {
+        channel.sendResponse(response);
+        verify(originalChannel).sendResponse(response);
+        verify(cpuUtilizationHistogram, times(1)).record(anyDouble(), any(Tags.class));
+    }
+
+    @Test
+    public void testResponseWithException() throws IOException {
+        Exception exception = new Exception("dummy exception");
+        channel.sendResponse(exception);
+        verify(originalChannel).sendResponse(exception);
+        verify(cpuUtilizationHistogram, times(1)).record(anyDouble(), any(Tags.class));
+    }
+
+    @Test
+    public void testRecordCPUUtilizationMetric() {
+        RTFPerformanceAnalyzerTransportChannel channel =
+                new RTFPerformanceAnalyzerTransportChannel();
+        channel.set(originalChannel, cpuUtilizationHistogram, "testIndex", mockedShardId, false);
+        Mockito.when(mockedShardId.getIndex()).thenReturn(index);
+        Mockito.when(index.getName()).thenReturn("myTestIndex");
+        Mockito.when(index.getUUID()).thenReturn("abc-def");
+        channel.recordCPUUtilizationMetric(mockedShardId, 10l, "bulkShard", false);
+        Mockito.verify(cpuUtilizationHistogram)
+                .record(Mockito.anyDouble(), Mockito.any(Tags.class));
+    }
+}

--- a/src/test/java/org/opensearch/performanceanalyzer/transport/RTFPerformanceAnalyzerTransportRequestHandlerTests.java
+++ b/src/test/java/org/opensearch/performanceanalyzer/transport/RTFPerformanceAnalyzerTransportRequestHandlerTests.java
@@ -65,7 +65,7 @@ public class RTFPerformanceAnalyzerTransportRequestHandlerTests {
     @Test
     public void testGetChannel() {
         OpenSearchResources.INSTANCE.setMetricsRegistry(metricsRegistry);
-        Mockito.when(controller.getCollectorsSettingValue())
+        Mockito.when(controller.getCollectorsRunModeValue())
                 .thenReturn(Util.CollectorMode.TELEMETRY.getValue());
         concreteShardRequest = new ConcreteShardRequest(bulkShardRequest, "id", 1);
         handler.getChannel(concreteShardRequest, channel, task);
@@ -79,7 +79,7 @@ public class RTFPerformanceAnalyzerTransportRequestHandlerTests {
     @Test
     public void testGetChannelTelemetryIsDisabled() {
         OpenSearchResources.INSTANCE.setMetricsRegistry(metricsRegistry);
-        Mockito.when(controller.getCollectorsSettingValue())
+        Mockito.when(controller.getCollectorsRunModeValue())
                 .thenReturn(Util.CollectorMode.RCA.getValue());
         concreteShardRequest = new ConcreteShardRequest(bulkShardRequest, "id", 1);
         handler.getChannel(concreteShardRequest, channel, task);
@@ -93,7 +93,7 @@ public class RTFPerformanceAnalyzerTransportRequestHandlerTests {
     @Test
     public void testGetChannelDualMode() {
         OpenSearchResources.INSTANCE.setMetricsRegistry(metricsRegistry);
-        Mockito.when(controller.getCollectorsSettingValue())
+        Mockito.when(controller.getCollectorsRunModeValue())
                 .thenReturn(Util.CollectorMode.DUAL.getValue());
         concreteShardRequest = new ConcreteShardRequest(bulkShardRequest, "id", 1);
         handler.getChannel(concreteShardRequest, channel, task);
@@ -107,7 +107,7 @@ public class RTFPerformanceAnalyzerTransportRequestHandlerTests {
     @Test
     public void testGetChannelMetricRegistryIsNull() {
         OpenSearchResources.INSTANCE.setMetricsRegistry(null);
-        Mockito.when(controller.getCollectorsSettingValue())
+        Mockito.when(controller.getCollectorsRunModeValue())
                 .thenReturn(Util.CollectorMode.RCA.getValue());
         concreteShardRequest = new ConcreteShardRequest(bulkShardRequest, "id", 1);
         handler.getChannel(concreteShardRequest, channel, task);

--- a/src/test/java/org/opensearch/performanceanalyzer/util/UtilsTests.java
+++ b/src/test/java/org/opensearch/performanceanalyzer/util/UtilsTests.java
@@ -1,0 +1,27 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.performanceanalyzer.util;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+public class UtilsTests {
+
+    @Test
+    public void testCPUUtilization() {
+        Assert.assertEquals(0.5, Utils.calculateCPUUtilization(2, 5, 5), 0.0);
+        Assert.assertEquals(1.0, Utils.calculateCPUUtilization(1, 5, 5), 0.0);
+        Assert.assertEquals(
+                Double.valueOf(10 / 15.0), Utils.calculateCPUUtilization(3, 5, 10), 0.0);
+    }
+
+    @Test
+    public void testCPUUtilizationZeroValue() {
+        Assert.assertEquals(0.0, Utils.calculateCPUUtilization(2, 5, 0), 0.0);
+        Assert.assertEquals(0.0, Utils.calculateCPUUtilization(2, 0, 5), 0.0);
+        Assert.assertEquals(0.0, Utils.calculateCPUUtilization(0, 5, 5), 0.0);
+    }
+}

--- a/src/test/java/org/opensearch/performanceanalyzer/util/UtilsTests.java
+++ b/src/test/java/org/opensearch/performanceanalyzer/util/UtilsTests.java
@@ -12,16 +12,21 @@ public class UtilsTests {
 
     @Test
     public void testCPUUtilization() {
-        Assert.assertEquals(0.5, Utils.calculateCPUUtilization(2, 5, 5), 0.0);
-        Assert.assertEquals(1.0, Utils.calculateCPUUtilization(1, 5, 5), 0.0);
+        Assert.assertEquals(0.5, Utils.calculateCPUUtilization(2, 5, 5, 1.0), 0.0);
+        Assert.assertEquals(1.0, Utils.calculateCPUUtilization(1, 5, 5, 1.0), 0.0);
         Assert.assertEquals(
-                Double.valueOf(10 / 15.0), Utils.calculateCPUUtilization(3, 5, 10), 0.0);
+                Double.valueOf(10 / 15.0), Utils.calculateCPUUtilization(3, 5, 10, 1.0), 0.0);
+        Assert.assertEquals(
+                Double.valueOf(0.50 * (20 / 30.0)),
+                Utils.calculateCPUUtilization(3, 10, 20, 0.5d),
+                0.0);
     }
 
     @Test
     public void testCPUUtilizationZeroValue() {
-        Assert.assertEquals(0.0, Utils.calculateCPUUtilization(2, 5, 0), 0.0);
-        Assert.assertEquals(0.0, Utils.calculateCPUUtilization(2, 0, 5), 0.0);
-        Assert.assertEquals(0.0, Utils.calculateCPUUtilization(0, 5, 5), 0.0);
+        Assert.assertEquals(0.0, Utils.calculateCPUUtilization(2, 5, 0, 1.0), 0.0);
+        Assert.assertEquals(0.0, Utils.calculateCPUUtilization(2, 0, 5, 1.0), 0.0);
+        Assert.assertEquals(0.0, Utils.calculateCPUUtilization(0, 5, 5, 1.0), 0.0);
+        Assert.assertEquals(0.0, Utils.calculateCPUUtilization(0, 5, 5, 0.0), 0.0);
     }
 }


### PR DESCRIPTION
Adds the listener for resource utilization metrics.
1. RTFPerformanceAnalyzerSearchListener - Emits the CPU_Utilization and Heap_used metrics for task level query shard operations  (both query phase and the fetch phase).
2. RTFPerformanceAnalyzerTransportInterceptor - Emits the CPU_Utilization metric for BulkShardRequest.

**Is your feature request related to a problem? Please provide an existing Issue # , or describe.**
A clear and concise description of what the problem is. Ex. I'm always frustrated when [...]

**Describe the solution you are proposing**
A clear and concise description of what you want to happen.

**Describe alternatives you've considered**
A clear and concise description of any alternative solutions or features you've considered.

**Additional context**
Add any other context or screenshots about the feature request here.

### Check List
- [x] Backport Labels added.
- [x] New functionality includes testing.
  - [x] All tests pass
- [x] New functionality has been documented.
  - [x] New functionality has javadoc added
- [x] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/performance-analyzer/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
