### PR TITLE
Remove IdentityService from RestController constructor

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -10,7 +10,7 @@ buildscript {
         isSnapshot = "true" == System.getProperty("build.snapshot", "true")
         buildVersionQualifier = System.getProperty("build.version_qualifier", "")
 
-        default_bwc_version = System.getProperty("bwc.version", "2.12.0.0")
+        default_bwc_version = System.getProperty("bwc.version", "2.18.0.0")
         pa_bwc_version = System.getProperty("tests.bwc.version", default_bwc_version)
         baseName = "paBwcCluster"
 
@@ -669,7 +669,7 @@ task integTestRemote(type: RestIntegTestTask) {
     testClusters {
         "${baseName}$i" {
             testDistribution = "ARCHIVE"
-            versions = ["2.12.0-SNAPSHOT", opensearch_version]
+            versions = ["2.18.0-SNAPSHOT", opensearch_version]
             numberOfNodes = 3
             plugin(provider(new Callable<RegularFile>() {
                 @Override

--- a/src/test/java/org/opensearch/performanceanalyzer/PerformanceAnalyzerPluginTests.java
+++ b/src/test/java/org/opensearch/performanceanalyzer/PerformanceAnalyzerPluginTests.java
@@ -30,7 +30,6 @@ import org.opensearch.core.action.ActionResponse;
 import org.opensearch.core.indices.breaker.CircuitBreakerService;
 import org.opensearch.env.Environment;
 import org.opensearch.env.TestEnvironment;
-import org.opensearch.identity.IdentityService;
 import org.opensearch.indices.breaker.BreakerSettings;
 import org.opensearch.indices.breaker.HierarchyCircuitBreakerService;
 import org.opensearch.performanceanalyzer.action.PerformanceAnalyzerActionFilter;
@@ -64,7 +63,6 @@ public class PerformanceAnalyzerPluginTests extends OpenSearchTestCase {
     private CircuitBreakerService circuitBreakerService;
     private ClusterService clusterService;
     private ClusterSettings clusterSettings;
-    private IdentityService identityService;
 
     private MetricsRegistry metricsRegistry;
 
@@ -90,15 +88,13 @@ public class PerformanceAnalyzerPluginTests extends OpenSearchTestCase {
             e.printStackTrace();
         }
         clusterService = new ClusterService(settings, clusterSettings, threadPool);
-        identityService = new IdentityService(Settings.EMPTY, threadPool, List.of());
         restController =
                 new RestController(
                         Collections.emptySet(),
                         null,
                         nodeClient,
                         circuitBreakerService,
-                        usageService,
-                        identityService);
+                        usageService);
     }
 
     @After

--- a/src/test/java/org/opensearch/performanceanalyzer/http_action/config/PerformanceAnalyzerClusterConfigActionTests.java
+++ b/src/test/java/org/opensearch/performanceanalyzer/http_action/config/PerformanceAnalyzerClusterConfigActionTests.java
@@ -12,7 +12,6 @@ import static org.mockito.MockitoAnnotations.initMocks;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Collections;
-import java.util.List;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
@@ -28,7 +27,6 @@ import org.opensearch.core.indices.breaker.CircuitBreakerService;
 import org.opensearch.core.rest.RestStatus;
 import org.opensearch.core.xcontent.NamedXContentRegistry;
 import org.opensearch.core.xcontent.XContentBuilder;
-import org.opensearch.identity.IdentityService;
 import org.opensearch.indices.breaker.BreakerSettings;
 import org.opensearch.indices.breaker.HierarchyCircuitBreakerService;
 import org.opensearch.performanceanalyzer.config.PerformanceAnalyzerController;
@@ -54,7 +52,6 @@ public class PerformanceAnalyzerClusterConfigActionTests {
     private PerformanceAnalyzerClusterSettingHandler clusterSettingHandler;
     private NodeStatsSettingHandler nodeStatsSettingHandler;
     private PerformanceAnalyzerCollectorsSettingHandler performanceAnalyzerCollectorsSettingHandler;
-    private IdentityService identityService;
 
     @Mock private PerformanceAnalyzerController controller;
     @Mock private ClusterSettingsManager clusterSettingsManager;
@@ -71,15 +68,13 @@ public class PerformanceAnalyzerClusterConfigActionTests {
         UsageService usageService = new UsageService();
         threadPool = new TestThreadPool("test");
         nodeClient = new NodeClient(Settings.EMPTY, threadPool);
-        identityService = new IdentityService(Settings.EMPTY, threadPool, List.of());
         restController =
                 new RestController(
                         Collections.emptySet(),
                         null,
                         nodeClient,
                         circuitBreakerService,
-                        usageService,
-                        identityService);
+                        usageService);
         clusterSettingHandler =
                 new PerformanceAnalyzerClusterSettingHandler(controller, clusterSettingsManager);
         nodeStatsSettingHandler = new NodeStatsSettingHandler(controller, clusterSettingsManager);

--- a/src/test/java/org/opensearch/performanceanalyzer/http_action/config/PerformanceAnalyzerConfigActionTests.java
+++ b/src/test/java/org/opensearch/performanceanalyzer/http_action/config/PerformanceAnalyzerConfigActionTests.java
@@ -12,7 +12,6 @@ import static org.mockito.MockitoAnnotations.initMocks;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Collections;
-import java.util.List;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
@@ -29,7 +28,6 @@ import org.opensearch.core.indices.breaker.CircuitBreakerService;
 import org.opensearch.core.rest.RestStatus;
 import org.opensearch.core.xcontent.NamedXContentRegistry;
 import org.opensearch.core.xcontent.XContentBuilder;
-import org.opensearch.identity.IdentityService;
 import org.opensearch.indices.breaker.BreakerSettings;
 import org.opensearch.indices.breaker.HierarchyCircuitBreakerService;
 import org.opensearch.performanceanalyzer.config.PerformanceAnalyzerController;
@@ -48,7 +46,6 @@ public class PerformanceAnalyzerConfigActionTests {
     private NodeClient nodeClient;
     private CircuitBreakerService circuitBreakerService;
     private ClusterSettings clusterSettings;
-    private IdentityService identityService;
 
     @Mock private PerformanceAnalyzerController controller;
 
@@ -64,15 +61,13 @@ public class PerformanceAnalyzerConfigActionTests {
         UsageService usageService = new UsageService();
         threadPool = new TestThreadPool("test");
         nodeClient = new NodeClient(Settings.EMPTY, threadPool);
-        identityService = new IdentityService(Settings.EMPTY, threadPool, List.of());
         restController =
                 new RestController(
                         Collections.emptySet(),
                         null,
                         nodeClient,
                         circuitBreakerService,
-                        usageService,
-                        identityService);
+                        usageService);
         configAction = new PerformanceAnalyzerConfigAction(restController, controller);
         restController.registerHandler(configAction);
 

--- a/src/test/java/org/opensearch/performanceanalyzer/http_action/config/PerformanceAnalyzerOverridesClusterConfigActionTests.java
+++ b/src/test/java/org/opensearch/performanceanalyzer/http_action/config/PerformanceAnalyzerOverridesClusterConfigActionTests.java
@@ -13,7 +13,6 @@ import java.io.IOException;
 import java.nio.ByteBuffer;
 import java.util.ArrayList;
 import java.util.Collections;
-import java.util.List;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
@@ -27,7 +26,6 @@ import org.opensearch.core.common.bytes.BytesReference;
 import org.opensearch.core.indices.breaker.CircuitBreakerService;
 import org.opensearch.core.rest.RestStatus;
 import org.opensearch.core.xcontent.NamedXContentRegistry;
-import org.opensearch.identity.IdentityService;
 import org.opensearch.indices.breaker.BreakerSettings;
 import org.opensearch.indices.breaker.HierarchyCircuitBreakerService;
 import org.opensearch.performanceanalyzer.commons.config.overrides.ConfigOverridesWrapper;
@@ -48,7 +46,6 @@ public class PerformanceAnalyzerOverridesClusterConfigActionTests {
     private NodeClient nodeClient;
     private CircuitBreakerService circuitBreakerService;
     private ClusterSettings clusterSettings;
-    private IdentityService identityService;
 
     @Mock private ConfigOverridesClusterSettingHandler configOverridesClusterSettingHandler;
     @Mock private ConfigOverridesWrapper overridesWrapper;
@@ -65,15 +62,13 @@ public class PerformanceAnalyzerOverridesClusterConfigActionTests {
         UsageService usageService = new UsageService();
         threadPool = new TestThreadPool("test");
         nodeClient = new NodeClient(Settings.EMPTY, threadPool);
-        identityService = new IdentityService(Settings.EMPTY, threadPool, List.of());
         restController =
                 new RestController(
                         Collections.emptySet(),
                         null,
                         nodeClient,
                         circuitBreakerService,
-                        usageService,
-                        identityService);
+                        usageService);
         configAction =
                 new PerformanceAnalyzerOverridesClusterConfigAction(
                         Settings.EMPTY,


### PR DESCRIPTION
### Description

This PR fixes compilation issues in PA tests due to change in the constructor of the RestController in https://github.com/opensearch-project/OpenSearch/pull/15430

### Related Issues
Resolves https://github.com/opensearch-project/performance-analyzer/issues/731 and https://github.com/opensearch-project/performance-analyzer/issues/732

### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md).
- [ ] Commits are signed per the DCO using `--signoff`.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/performance-analyzer/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
