### PR TITLE
Fixes the Gauge instrument to be created only once

### DIFF
--- a/src/test/java/org/opensearch/performanceanalyzer/collectors/telemetry/RTFCacheConfigMetricsCollectorTests.java
+++ b/src/test/java/org/opensearch/performanceanalyzer/collectors/telemetry/RTFCacheConfigMetricsCollectorTests.java
@@ -9,6 +9,7 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.atLeastOnce;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.verify;
 
@@ -29,6 +30,7 @@ public class RTFCacheConfigMetricsCollectorTests extends OpenSearchSingleNodeTes
     private static final String TEST_INDEX = "test";
     private RTFCacheConfigMetricsCollector rtfCacheConfigMetricsCollector;
     private static MetricsRegistry metricsRegistry;
+    private static MetricsRegistry metricsRegistry1;
     private long startTimeInMills = 1153721339;
 
     @Before
@@ -36,6 +38,7 @@ public class RTFCacheConfigMetricsCollectorTests extends OpenSearchSingleNodeTes
         MetricsConfiguration.CONFIG_MAP.put(
                 RTFCacheConfigMetricsCollector.class, MetricsConfiguration.cdefault);
         metricsRegistry = mock(MetricsRegistry.class);
+        metricsRegistry1 = mock(MetricsRegistry.class);
         OpenSearchResources.INSTANCE.setMetricsRegistry(metricsRegistry);
         IndicesService indicesService = getInstanceFromNode(IndicesService.class);
         OpenSearchResources.INSTANCE.setIndicesService(indicesService);
@@ -56,6 +59,19 @@ public class RTFCacheConfigMetricsCollectorTests extends OpenSearchSingleNodeTes
         createIndex(TEST_INDEX);
         rtfCacheConfigMetricsCollector.collectMetrics(startTimeInMills);
         verify(metricsRegistry, atLeastOnce())
+                .createGauge(anyString(), anyString(), anyString(), any(), any());
+    }
+
+    @Test
+    public void testCollectMetricsRepeated() throws IOException {
+        createIndex(TEST_INDEX);
+        rtfCacheConfigMetricsCollector.collectMetrics(startTimeInMills);
+        verify(metricsRegistry, atLeastOnce())
+                .createGauge(anyString(), anyString(), anyString(), any(), any());
+
+        OpenSearchResources.INSTANCE.setMetricsRegistry(metricsRegistry1);
+        rtfCacheConfigMetricsCollector.collectMetrics(startTimeInMills);
+        verify(metricsRegistry1, never())
                 .createGauge(anyString(), anyString(), anyString(), any(), any());
     }
 }

--- a/src/test/java/org/opensearch/performanceanalyzer/collectors/telemetry/RTFHeapMetricsCollectorTests.java
+++ b/src/test/java/org/opensearch/performanceanalyzer/collectors/telemetry/RTFHeapMetricsCollectorTests.java
@@ -25,6 +25,7 @@ public class RTFHeapMetricsCollectorTests extends CollectorTestBase {
     private RTFHeapMetricsCollector rtfHeapMetricsCollector;
 
     private static MetricsRegistry metricsRegistry;
+    private static MetricsRegistry metricsRegistry1;
     private static Histogram gcCollectionEventHistogram;
     private static Histogram gcCollectionTimeHistogram;
     private static Histogram heapUsedHistogram;
@@ -35,6 +36,7 @@ public class RTFHeapMetricsCollectorTests extends CollectorTestBase {
                 RTFHeapMetricsCollector.class, MetricsConfiguration.cdefault);
 
         metricsRegistry = mock(MetricsRegistry.class);
+        metricsRegistry1 = mock(MetricsRegistry.class);
         gcCollectionEventHistogram = mock(Histogram.class);
         gcCollectionTimeHistogram = mock(Histogram.class);
         heapUsedHistogram = mock(Histogram.class);
@@ -63,6 +65,22 @@ public class RTFHeapMetricsCollectorTests extends CollectorTestBase {
         verify(gcCollectionTimeHistogram, atLeastOnce()).record(anyDouble(), any());
         verify(gcCollectionEventHistogram, atLeastOnce()).record(anyDouble(), any());
         verify(metricsRegistry, atLeastOnce())
+                .createGauge(anyString(), anyString(), anyString(), any(), any());
+    }
+
+    @Test
+    public void testCollectMetricsRepeated() throws IOException {
+
+        rtfHeapMetricsCollector.collectMetrics(System.currentTimeMillis());
+        verify(heapUsedHistogram, atLeastOnce()).record(anyDouble(), any());
+        verify(gcCollectionTimeHistogram, atLeastOnce()).record(anyDouble(), any());
+        verify(gcCollectionEventHistogram, atLeastOnce()).record(anyDouble(), any());
+        verify(metricsRegistry, atLeastOnce())
+                .createGauge(anyString(), anyString(), anyString(), any(), any());
+
+        OpenSearchResources.INSTANCE.setMetricsRegistry(metricsRegistry1);
+        rtfHeapMetricsCollector.collectMetrics(System.currentTimeMillis());
+        verify(metricsRegistry1, never())
                 .createGauge(anyString(), anyString(), anyString(), any(), any());
     }
 }


### PR DESCRIPTION
### Description
Gauge Instrument was registering a new callback on each computation. Fixed it to be created only once for the first time.

### Related Issues
Resolves #[Issue number to be closed when this PR is merged]
<!-- List any other related issues here -->

### Check List
- [x] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md).
- [x] Commits are signed per the DCO using `--signoff`.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/performance-analyzer/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
