### PR TITLE
Fixes the re enabling of RTFCacheConfigMetricsCollector

### DIFF
--- a/src/main/java/org/opensearch/performanceanalyzer/collectors/telemetry/RTFCacheConfigMetricsCollector.java
+++ b/src/main/java/org/opensearch/performanceanalyzer/collectors/telemetry/RTFCacheConfigMetricsCollector.java
@@ -124,6 +124,9 @@ public class RTFCacheConfigMetricsCollector extends PerformanceAnalyzerMetricsCo
                 requestCacheGauge = null;
             }
         }
+        if (metricsInitialised) {
+            metricsInitialised = false;
+        }
     }
 
     private double getRequestCacheMaxSizeStatus(IndicesService indicesService) {

--- a/src/test/java/org/opensearch/performanceanalyzer/collectors/telemetry/RTFCacheConfigMetricsCollectorTests.java
+++ b/src/test/java/org/opensearch/performanceanalyzer/collectors/telemetry/RTFCacheConfigMetricsCollectorTests.java
@@ -7,12 +7,15 @@ package org.opensearch.performanceanalyzer.collectors.telemetry;
 
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.atLeastOnce;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 
+import java.io.Closeable;
 import java.io.IOException;
 import org.junit.After;
 import org.junit.Before;
@@ -31,6 +34,7 @@ public class RTFCacheConfigMetricsCollectorTests extends OpenSearchSingleNodeTes
     private RTFCacheConfigMetricsCollector rtfCacheConfigMetricsCollector;
     private static MetricsRegistry metricsRegistry;
     private static MetricsRegistry metricsRegistry1;
+    PerformanceAnalyzerController mockController;
     private long startTimeInMills = 1153721339;
 
     @Before
@@ -43,7 +47,7 @@ public class RTFCacheConfigMetricsCollectorTests extends OpenSearchSingleNodeTes
         IndicesService indicesService = getInstanceFromNode(IndicesService.class);
         OpenSearchResources.INSTANCE.setIndicesService(indicesService);
         ConfigOverridesWrapper mockWrapper = mock(ConfigOverridesWrapper.class);
-        PerformanceAnalyzerController mockController = mock(PerformanceAnalyzerController.class);
+        mockController = mock(PerformanceAnalyzerController.class);
         Mockito.when(mockController.isCollectorDisabled(any(), anyString())).thenReturn(false);
         rtfCacheConfigMetricsCollector =
                 spy(new RTFCacheConfigMetricsCollector(mockController, mockWrapper));
@@ -72,6 +76,41 @@ public class RTFCacheConfigMetricsCollectorTests extends OpenSearchSingleNodeTes
         OpenSearchResources.INSTANCE.setMetricsRegistry(metricsRegistry1);
         rtfCacheConfigMetricsCollector.collectMetrics(startTimeInMills);
         verify(metricsRegistry1, never())
+                .createGauge(anyString(), anyString(), anyString(), any(), any());
+    }
+
+    @Test
+    public void testCollectMetricsDisableEnable() throws IOException {
+        createIndex(TEST_INDEX);
+        Closeable fieldCacheGaugeObservable = Mockito.mock(Closeable.class);
+        Closeable requestCacheGaugeObservable = Mockito.mock(Closeable.class);
+
+        Mockito.when(
+                        metricsRegistry.createGauge(
+                                anyString(), anyString(), anyString(), any(), any()))
+                .thenReturn(requestCacheGaugeObservable, fieldCacheGaugeObservable);
+        rtfCacheConfigMetricsCollector.collectMetrics(startTimeInMills);
+        verify(metricsRegistry, times(2))
+                .createGauge(anyString(), anyString(), anyString(), any(), any());
+
+        OpenSearchResources.INSTANCE.setMetricsRegistry(metricsRegistry1);
+        Mockito.when(
+                        mockController.isCollectorDisabled(
+                                any(), eq("RTFCacheConfigMetricsCollector")))
+                .thenReturn(true);
+        rtfCacheConfigMetricsCollector.collectMetrics(startTimeInMills);
+        verify(fieldCacheGaugeObservable, Mockito.only()).close();
+        verify(requestCacheGaugeObservable, Mockito.only()).close();
+        verify(metricsRegistry1, never())
+                .createGauge(anyString(), anyString(), anyString(), any(), any());
+
+        OpenSearchResources.INSTANCE.setMetricsRegistry(metricsRegistry1);
+        Mockito.when(
+                        mockController.isCollectorDisabled(
+                                any(), eq("RTFCacheConfigMetricsCollector")))
+                .thenReturn(false);
+        rtfCacheConfigMetricsCollector.collectMetrics(startTimeInMills);
+        verify(metricsRegistry1, times(2))
                 .createGauge(anyString(), anyString(), anyString(), any(), any());
     }
 }


### PR DESCRIPTION
### Description
Fixes the case where if RTFCacheConfigMetricsCollector got disabled once and re enabled the Gauge instruments should be recreated.

### Related Issues
Resolves #[Issue number to be closed when this PR is merged]
<!-- List any other related issues here -->

### Check List
- [x] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md).
- [x] Commits are signed per the DCO using `--signoff`.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/performance-analyzer/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
