### PR TITLE
Add Indexing Latency, Indexing and Search Rate metric per shard

### DIFF
--- a/src/main/java/org/opensearch/performanceanalyzer/PerformanceAnalyzerPlugin.java
+++ b/src/main/java/org/opensearch/performanceanalyzer/PerformanceAnalyzerPlugin.java
@@ -58,6 +58,7 @@ import org.opensearch.performanceanalyzer.collectors.telemetry.RTFCacheConfigMet
 import org.opensearch.performanceanalyzer.collectors.telemetry.RTFDisksCollector;
 import org.opensearch.performanceanalyzer.collectors.telemetry.RTFHeapMetricsCollector;
 import org.opensearch.performanceanalyzer.collectors.telemetry.RTFNodeStatsAllShardsMetricsCollector;
+import org.opensearch.performanceanalyzer.collectors.telemetry.RTFShardOperationRateCollector;
 import org.opensearch.performanceanalyzer.collectors.telemetry.RTFThreadPoolMetricsCollector;
 import org.opensearch.performanceanalyzer.commons.OSMetricsGeneratorFactory;
 import org.opensearch.performanceanalyzer.commons.collectors.DisksCollector;
@@ -230,6 +231,9 @@ public final class PerformanceAnalyzerPlugin extends Plugin
                 new RTFDisksCollector(performanceAnalyzerController, configOverridesWrapper));
         scheduledMetricCollectorsExecutor.addScheduledMetricCollector(
                 new RTFHeapMetricsCollector(performanceAnalyzerController, configOverridesWrapper));
+        scheduledMetricCollectorsExecutor.addScheduledMetricCollector(
+                new RTFShardOperationRateCollector(
+                        performanceAnalyzerController, configOverridesWrapper));
         scheduledMetricCollectorsExecutor.addScheduledMetricCollector(
                 new RTFThreadPoolMetricsCollector(
                         performanceAnalyzerController, configOverridesWrapper));

--- a/src/main/java/org/opensearch/performanceanalyzer/collectors/telemetry/RTFShardOperationRateCollector.java
+++ b/src/main/java/org/opensearch/performanceanalyzer/collectors/telemetry/RTFShardOperationRateCollector.java
@@ -1,0 +1,171 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.performanceanalyzer.collectors.telemetry;
+
+import java.util.HashMap;
+import java.util.Map;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.opensearch.core.index.shard.ShardId;
+import org.opensearch.index.shard.IndexShard;
+import org.opensearch.performanceanalyzer.OpenSearchResources;
+import org.opensearch.performanceanalyzer.commons.collectors.PerformanceAnalyzerMetricsCollector;
+import org.opensearch.performanceanalyzer.commons.collectors.TelemetryCollector;
+import org.opensearch.performanceanalyzer.commons.config.overrides.ConfigOverridesWrapper;
+import org.opensearch.performanceanalyzer.commons.metrics.MetricsConfiguration;
+import org.opensearch.performanceanalyzer.commons.metrics.RTFMetrics;
+import org.opensearch.performanceanalyzer.commons.metrics.RTFMetrics.MetricUnits;
+import org.opensearch.performanceanalyzer.commons.stats.metrics.StatExceptionCode;
+import org.opensearch.performanceanalyzer.commons.stats.metrics.StatMetrics;
+import org.opensearch.performanceanalyzer.config.PerformanceAnalyzerController;
+import org.opensearch.performanceanalyzer.util.Utils;
+import org.opensearch.telemetry.metrics.Counter;
+import org.opensearch.telemetry.metrics.MetricsRegistry;
+import org.opensearch.telemetry.metrics.tags.Tags;
+
+/** This collector measures indexing and search rate per shard per minute. */
+public class RTFShardOperationRateCollector extends PerformanceAnalyzerMetricsCollector
+        implements TelemetryCollector {
+
+    private static final Logger LOG = LogManager.getLogger(RTFShardOperationRateCollector.class);
+    public static final int SAMPLING_TIME_INTERVAL =
+            MetricsConfiguration.CONFIG_MAP.get(RTFShardOperationRateCollector.class)
+                    .samplingInterval;
+
+    private Counter indexingRateHistogram;
+    private Counter searchRateHistogram;
+
+    private final Map<ShardId, Long> prevIndexingOps;
+    private final Map<ShardId, Long> prevSearchOps;
+    private long lastCollectionTimeInMillis;
+
+    private MetricsRegistry metricsRegistry;
+    private boolean metricsInitialized;
+    private final PerformanceAnalyzerController controller;
+    private final ConfigOverridesWrapper configOverridesWrapper;
+
+    public RTFShardOperationRateCollector(
+            PerformanceAnalyzerController controller,
+            ConfigOverridesWrapper configOverridesWrapper) {
+        super(
+                SAMPLING_TIME_INTERVAL,
+                "RTFShardOperationRateCollector",
+                StatMetrics.RTF_SHARD_OPERATION_RATE_COLLECTOR_EXECUTION_TIME,
+                StatExceptionCode.RTF_SHARD_OPERATION_RATE_COLLECTOR_ERROR);
+
+        this.controller = controller;
+        this.configOverridesWrapper = configOverridesWrapper;
+        this.metricsInitialized = false;
+
+        this.prevIndexingOps = new HashMap<>();
+        this.prevSearchOps = new HashMap<>();
+        this.lastCollectionTimeInMillis = System.currentTimeMillis();
+    }
+
+    @Override
+    public void collectMetrics(long startTime) {
+        if (controller.isCollectorDisabled(configOverridesWrapper, getCollectorName())) {
+            LOG.info("RTFShardOperationRateCollector is disabled. Skipping collection.");
+            return;
+        }
+
+        metricsRegistry = OpenSearchResources.INSTANCE.getMetricsRegistry();
+        if (metricsRegistry == null) {
+            LOG.error("Could not get the instance of MetricsRegistry class");
+            return;
+        }
+
+        initializeMetricsIfNeeded();
+        LOG.debug("Executing collect metrics for RTFShardOperationRateCollector");
+
+        long currentTimeInMillis = System.currentTimeMillis();
+        float minutesSinceLastCollection =
+                (currentTimeInMillis - lastCollectionTimeInMillis) / (1000.0f * 60.0f);
+
+        // Get all shards
+        Map<ShardId, IndexShard> currentShards = Utils.getShards();
+
+        for (Map.Entry<ShardId, IndexShard> entry : currentShards.entrySet()) {
+            ShardId shardId = entry.getKey();
+            IndexShard shard = entry.getValue();
+
+            try {
+                long currentIndexingOps = shard.indexingStats().getTotal().getIndexCount();
+                long currentSearchOps = shard.searchStats().getTotal().getQueryCount();
+
+                if (prevIndexingOps.containsKey(shardId)) {
+                    processIndexingOperations(
+                            shardId, currentIndexingOps, minutesSinceLastCollection);
+                }
+
+                if (prevSearchOps.containsKey(shardId)) {
+                    processSearchOperations(shardId, currentSearchOps, minutesSinceLastCollection);
+                }
+
+                // Update previous values for next collection
+                prevIndexingOps.put(shardId, currentIndexingOps);
+                prevSearchOps.put(shardId, currentSearchOps);
+            } catch (Exception e) {
+                LOG.error(
+                        "Error collecting indexing/search rate metrics for shard {}: {}",
+                        shardId,
+                        e.getMessage());
+            }
+        }
+
+        lastCollectionTimeInMillis = currentTimeInMillis;
+    }
+
+    private void processIndexingOperations(
+            ShardId shardId, long currentIndexingOps, float minutesSinceLastCollection) {
+        long indexingOpsDiff = Math.max(0, currentIndexingOps - prevIndexingOps.get(shardId));
+        float indexingRatePerMinute = indexingOpsDiff / minutesSinceLastCollection;
+
+        // Round to 2 decimal places
+        indexingRatePerMinute = Math.round(indexingRatePerMinute * 100.0f) / 100.0f;
+
+        Tags tags = createTags(shardId);
+        indexingRateHistogram.add(indexingRatePerMinute, tags);
+    }
+
+    private void processSearchOperations(
+            ShardId shardId, long currentSearchOps, float minutesSinceLastCollection) {
+        long searchOpsDiff = Math.max(0, currentSearchOps - prevSearchOps.get(shardId));
+        float searchRatePerMinute = searchOpsDiff / minutesSinceLastCollection;
+
+        // Round to 2 decimal places
+        searchRatePerMinute = Math.round(searchRatePerMinute * 100.0f) / 100.0f;
+
+        Tags tags = createTags(shardId);
+        searchRateHistogram.add(searchRatePerMinute, tags);
+    }
+
+    private Tags createTags(ShardId shardId) {
+        return Tags.create()
+                .addTag(RTFMetrics.CommonDimension.INDEX_NAME.toString(), shardId.getIndexName())
+                .addTag(
+                        RTFMetrics.CommonDimension.SHARD_ID.toString(),
+                        String.valueOf(shardId.getId()));
+    }
+
+    private void initializeMetricsIfNeeded() {
+        if (!metricsInitialized) {
+            indexingRateHistogram =
+                    metricsRegistry.createCounter(
+                            RTFMetrics.OperationsValue.Constants.INDEXING_RATE,
+                            "Indexing operations per minute per shard",
+                            MetricUnits.RATE.toString());
+
+            searchRateHistogram =
+                    metricsRegistry.createCounter(
+                            RTFMetrics.OperationsValue.Constants.SEARCH_RATE,
+                            "Search operations per minute per shard",
+                            MetricUnits.RATE.toString());
+
+            metricsInitialized = true;
+        }
+    }
+}

--- a/src/main/java/org/opensearch/performanceanalyzer/util/Utils.java
+++ b/src/main/java/org/opensearch/performanceanalyzer/util/Utils.java
@@ -50,6 +50,9 @@ public class Utils {
         MetricsConfiguration.CONFIG_MAP.put(RTFDisksCollector.class, cdefault);
         MetricsConfiguration.CONFIG_MAP.put(RTFHeapMetricsCollector.class, cdefault);
         MetricsConfiguration.CONFIG_MAP.put(
+                RTFShardOperationRateCollector.class,
+                new MetricsConfiguration.MetricConfig(60000, 0));
+        MetricsConfiguration.CONFIG_MAP.put(
                 RTFNodeStatsAllShardsMetricsCollector.class,
                 new MetricsConfiguration.MetricConfig(60000, 0));
         MetricsConfiguration.CONFIG_MAP.put(RTFThreadPoolMetricsCollector.class, cdefault);

--- a/src/test/java/org/opensearch/performanceanalyzer/collectors/telemetry/RTFShardOperationRateCollectorTests.java
+++ b/src/test/java/org/opensearch/performanceanalyzer/collectors/telemetry/RTFShardOperationRateCollectorTests.java
@@ -1,0 +1,98 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.performanceanalyzer.collectors.telemetry;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyDouble;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.atLeastOnce;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.io.IOException;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+import org.opensearch.indices.IndicesService;
+import org.opensearch.performanceanalyzer.OpenSearchResources;
+import org.opensearch.performanceanalyzer.commons.config.overrides.ConfigOverridesWrapper;
+import org.opensearch.performanceanalyzer.commons.metrics.MetricsConfiguration;
+import org.opensearch.performanceanalyzer.commons.metrics.RTFMetrics;
+import org.opensearch.performanceanalyzer.config.PerformanceAnalyzerController;
+import org.opensearch.telemetry.metrics.Counter;
+import org.opensearch.telemetry.metrics.MetricsRegistry;
+import org.opensearch.test.OpenSearchSingleNodeTestCase;
+
+public class RTFShardOperationRateCollectorTests extends OpenSearchSingleNodeTestCase {
+
+    private long startTimeInMills = 1153721339;
+    private static final String TEST_INDEX = "test";
+    private RTFShardOperationRateCollector rtfShardOperationRateCollector;
+
+    @Mock private MetricsRegistry metricsRegistry;
+    @Mock private Counter indexingRateCounter;
+    @Mock private Counter searchRateCounter;
+    @Mock private ConfigOverridesWrapper configOverridesWrapper;
+    @Mock private PerformanceAnalyzerController performanceAnalyzerController;
+
+    @Before
+    public void init() {
+        MockitoAnnotations.initMocks(this);
+
+        MetricsConfiguration.CONFIG_MAP.put(
+                RTFShardOperationRateCollector.class, MetricsConfiguration.cdefault);
+        IndicesService indicesService = getInstanceFromNode(IndicesService.class);
+        OpenSearchResources.INSTANCE.setIndicesService(indicesService);
+        OpenSearchResources.INSTANCE.setMetricsRegistry(metricsRegistry);
+
+        when(metricsRegistry.createCounter(anyString(), anyString(), anyString()))
+                .thenReturn(indexingRateCounter)
+                .thenReturn(searchRateCounter);
+
+        when(metricsRegistry.createCounter(anyString(), anyString(), anyString()))
+                .thenAnswer(
+                        invocationOnMock -> {
+                            String counterName = (String) invocationOnMock.getArguments()[0];
+                            if (counterName.contains(
+                                    RTFMetrics.OperationsValue.Constants.INDEXING_RATE)) {
+                                return indexingRateCounter;
+                            }
+                            return searchRateCounter;
+                        });
+
+        when(performanceAnalyzerController.isCollectorDisabled(any(), anyString()))
+                .thenReturn(false);
+
+        rtfShardOperationRateCollector =
+                spy(
+                        new RTFShardOperationRateCollector(
+                                performanceAnalyzerController, configOverridesWrapper));
+    }
+
+    @Test
+    public void testCollectMetrics() throws IOException {
+        createIndex(TEST_INDEX);
+        rtfShardOperationRateCollector.collectMetrics(startTimeInMills);
+
+        verify(indexingRateCounter, never()).add(anyDouble(), any());
+        verify(searchRateCounter, never()).add(anyDouble(), any());
+
+        startTimeInMills += 60000;
+        rtfShardOperationRateCollector.collectMetrics(startTimeInMills);
+
+        verify(indexingRateCounter, atLeastOnce()).add(anyDouble(), any());
+        verify(searchRateCounter, atLeastOnce()).add(anyDouble(), any());
+    }
+
+    @After
+    public void tearDown() throws Exception {
+        super.tearDown();
+    }
+}

--- a/src/test/java/org/opensearch/performanceanalyzer/transport/RTFPerformanceAnalyzerTransportChannelTests.java
+++ b/src/test/java/org/opensearch/performanceanalyzer/transport/RTFPerformanceAnalyzerTransportChannelTests.java
@@ -32,6 +32,7 @@ public class RTFPerformanceAnalyzerTransportChannelTests {
     @Mock private TransportChannel originalChannel;
     @Mock private TransportResponse response;
     @Mock private Histogram cpuUtilizationHistogram;
+    @Mock private Histogram indexingLatencyHistogram;
     private ShardId shardId;
     @Mock private ShardId mockedShardId;
     @Mock private Index index;
@@ -46,7 +47,13 @@ public class RTFPerformanceAnalyzerTransportChannelTests {
         String indexName = "testIndex";
         shardId = new ShardId(new Index(indexName, "uuid"), 1);
         channel = new RTFPerformanceAnalyzerTransportChannel();
-        channel.set(originalChannel, cpuUtilizationHistogram, indexName, shardId, false);
+        channel.set(
+                originalChannel,
+                cpuUtilizationHistogram,
+                indexingLatencyHistogram,
+                indexName,
+                shardId,
+                false);
         assertEquals("RTFPerformanceAnalyzerTransportChannelProfile", channel.getProfileName());
         assertEquals("RTFPerformanceAnalyzerTransportChannelType", channel.getChannelType());
         assertEquals(originalChannel, channel.getInnerChannel());
@@ -71,12 +78,37 @@ public class RTFPerformanceAnalyzerTransportChannelTests {
     public void testRecordCPUUtilizationMetric() {
         RTFPerformanceAnalyzerTransportChannel channel =
                 new RTFPerformanceAnalyzerTransportChannel();
-        channel.set(originalChannel, cpuUtilizationHistogram, "testIndex", mockedShardId, false);
+        channel.set(
+                originalChannel,
+                cpuUtilizationHistogram,
+                indexingLatencyHistogram,
+                "testIndex",
+                mockedShardId,
+                false);
         Mockito.when(mockedShardId.getIndex()).thenReturn(index);
         Mockito.when(index.getName()).thenReturn("myTestIndex");
         Mockito.when(index.getUUID()).thenReturn("abc-def");
         channel.recordCPUUtilizationMetric(mockedShardId, 10l, "bulkShard", false);
         Mockito.verify(cpuUtilizationHistogram)
+                .record(Mockito.anyDouble(), Mockito.any(Tags.class));
+    }
+
+    @Test
+    public void testRecordIndexingLatencyMetric() {
+        RTFPerformanceAnalyzerTransportChannel channel =
+                new RTFPerformanceAnalyzerTransportChannel();
+        channel.set(
+                originalChannel,
+                cpuUtilizationHistogram,
+                indexingLatencyHistogram,
+                "testIndex",
+                mockedShardId,
+                false);
+        Mockito.when(mockedShardId.getIndex()).thenReturn(index);
+        Mockito.when(index.getName()).thenReturn("myTestIndex");
+        Mockito.when(index.getUUID()).thenReturn("abc-def");
+        channel.recordIndexingLatencyMetric(123.456);
+        Mockito.verify(indexingLatencyHistogram)
                 .record(Mockito.anyDouble(), Mockito.any(Tags.class));
     }
 }


### PR DESCRIPTION
### Description
This commit will add 3 metrics per shard which are - 
1. Indexing Rate
2. Search Rate
3. Indexing Latency

These will be helpful to get detailed insights at shard level. 

### Related Issues
None

### Check List
- [x] New functionality includes testing.
- [ ] New functionality has been documented - Added required comment but not documented
- [x] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md).
- [x] Commits are signed per the DCO using `--signoff`.
- [x] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/performance-analyzer/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
