### PR TITLE
Bump checkstyle and spotbug versions (#833)

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -49,7 +49,7 @@ buildscript {
 plugins {
     id 'java'
     id 'com.netflix.nebula.ospackage' version "11.6.0"
-    id 'com.github.spotbugs' version '6.2.2'
+    id 'com.github.spotbugs' version '6.2.4'
     id 'jacoco'
     id 'com.diffplug.spotless' version '6.25.0'
     id 'checkstyle'
@@ -59,7 +59,7 @@ plugins {
 }
 
 checkstyle {
-    toolVersion = '10.26.1'
+    toolVersion = '11.0.0'
     configFile file("checkstyle/checkstyle.xml")
 }
 


### PR DESCRIPTION
### Description
Bump checkstyle and spotbug versions (#833)

Cherry picking https://github.com/opensearch-project/performance-analyzer/pull/833

### Related Issues
Resolves [CVE-2025-48734](https://advisories.opensearch.org/advisories/CVE-2025-48734) and [CVE-2025-27820](https://advisories.opensearch.org/advisories/CVE-2025-27820)

### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md).
- [ ] Commits are signed per the DCO using `--signoff`.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/performance-analyzer/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
