### PR TITLE
Fix CVE-2025-8916: Bump org.bouncycastle:bcpkix-jdk18on to 1.79

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -302,7 +302,7 @@ dependencies {
     implementation 'org.jooq:jooq:3.10.8'
     implementation 'org.apache.commons:commons-lang3:3.9'
     implementation 'org.bouncycastle:bcprov-jdk15to18:1.78.1'
-    implementation 'org.bouncycastle:bcpkix-jdk18on:1.78.1'
+    implementation 'org.bouncycastle:bcpkix-jdk18on:1.79'
     implementation "org.opensearch:performance-analyzer-commons:${paCommonsVersion}"
     implementation "com.fasterxml.jackson.core:jackson-annotations:${jacksonVersion}"
     implementation "com.fasterxml.jackson.core:jackson-databind:${jacksonDataBindVersion}"


### PR DESCRIPTION
### Description
Fix CVE-2025-8916: Bump org.bouncycastle:bcpkix-jdk18on to 1.79

### Related Issues
Resolves [CVE-2025-8916](https://advisories.opensearch.org/advisories/CVE-2025-8916)

### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md).
- [ ] Commits are signed per the DCO using `--signoff`.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/performance-analyzer/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
