### PR TITLE
Upgrades the commons-lang3 version (#848)

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -300,7 +300,7 @@ dependencies {
     }
 
     implementation 'org.jooq:jooq:3.10.8'
-    implementation 'org.apache.commons:commons-lang3:3.9'
+    implementation 'org.apache.commons:commons-lang3:${versions.commonslang}'
     implementation 'org.bouncycastle:bcprov-jdk15to18:1.78.1'
     implementation 'org.bouncycastle:bcpkix-jdk18on:1.78.1'
     implementation "org.opensearch:performance-analyzer-commons:${paCommonsVersion}"


### PR DESCRIPTION
### Description
Backport https://github.com/opensearch-project/performance-analyzer/pull/848

versions.commonslang is bumped to 3.18 on OS 2.19
```
ajnelapu@c889f3edb550 performance-analyzer % ./gradlew properties | grep 'versions'
versions: {junit5=5.14.0, protobuf=3.25.5, jmh=1.35, arrow=17.0.0, reactor_netty=1.2.9, commonslang=3.18.0, commonslogging=1.2, bouncycastle=1.82, commonscodec=1.18.0, woodstox=6.4.0, google_http_client=1.44.1, jakarta_annotation=1.3.5, jettison=1.5.4, jna=5.13.0, slf4j=1.7.36, hdrhistogram=2.2.2, bundled_jdk_vendor=adoptium, httpasyncclient=4.1.5, grpc=1.75.0, opentelemetrysemconv=1.29.0-alpha, flatbuffers=2.0.0, joda=2.12.7, jzlib=1.1.3, resteasy=6.2.4.Final, httpcore=4.4.16, reactor=3.7.5, lucene=9.12.3, roaringbitmap=1.3.0, mockito=5.14.2, zstd=1.5.5-5, jackson=2.18.2, bytebuddy=1.15.10, tdigest=3.2, log4j=2.21.0, netty=4.1.125.Final, reactivestreams=1.0.4, spatial4j=0.7, junit=4.13.2, commonscompress=1.28.0, icu4j=75.1, json_smart=2.5.2, jts=1.15.0, kotlin=1.7.10, supercsv=2.4.0, google_auth=1.29.0, randomizedrunner=2.7.1, antlr4=4.13.1, objenesis=3.3, opensearch=2.19.4-SNAPSHOT, bundled_jdk=21.0.8+9, jackson_databind=2.18.2, asm=9.7, opentelemetry=1.46.0, aws=2.20.86, guava=33.2.1-jre, hamcrest=2.1, commonsio=2.16.0, httpclient=4.5.14, snakeyaml=2.1}
```

### Related Issues
Resolves CVE-2025-48924

### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md).
- [ ] Commits are signed per the DCO using `--signoff`.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/performance-analyzer/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
