### PR TITLE
Hardcode BWC to 2.19 to mitigate build failure

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -10,7 +10,8 @@ buildscript {
         isSnapshot = "true" == System.getProperty("build.snapshot", "true")
         buildVersionQualifier = System.getProperty("build.version_qualifier", "")
 
-        default_bwc_version = System.getProperty("bwc.version", "2.17.0.0")
+        // Hardcoding BWC to 2.19 as maven does not have older version snapshots resulting in build failure
+        default_bwc_version = System.getProperty("bwc.version", "2.19.0.0")
         pa_bwc_version = System.getProperty("tests.bwc.version", default_bwc_version)
         baseName = "paBwcCluster"
 


### PR DESCRIPTION
### Description
Hardcoding BWC to 2.19 as maven does not have older version snapshots resulting in build failure

### Related Issues
BWC test failure

### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md).
- [ ] Commits are signed per the DCO using `--signoff`.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/performance-analyzer/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
