### PR TITLE
Bump bcpkix-jdk18on and commons-lang3

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -296,15 +296,14 @@ dependencies {
             force "com.fasterxml.jackson.dataformat:jackson-dataformat-cbor:${jacksonVersion}"
             force "org.apache.commons:commons-lang3:${versions.commonslang}"
             force "org.slf4j:slf4j-api:2.0.0"
-            force "org.apache.bcel:bcel:6.6.0" // This line should be removed once Spotbugs is upgraded to 4.7.4
             force "com.google.guava:guava:${guavaVersion}"
         }
     }
 
     implementation 'org.jooq:jooq:3.10.8'
-    implementation 'org.apache.commons:commons-lang3:3.9'
+    implementation "org.apache.commons:commons-lang3:${versions.commonslang}"
     implementation 'org.bouncycastle:bcprov-jdk15to18:1.78.1'
-    implementation 'org.bouncycastle:bcpkix-jdk18on:1.78.1'
+    implementation 'org.bouncycastle:bcpkix-jdk18on:1.79'
     implementation "org.opensearch:performance-analyzer-commons:${paCommonsVersion}"
     implementation "com.fasterxml.jackson.core:jackson-annotations:${jacksonVersion}"
     implementation "com.fasterxml.jackson.core:jackson-databind:${jacksonDataBindVersion}"


### PR DESCRIPTION
### Description
Bump bcpkix-jdk18on and commons-lang3

### Related Issues
Resolves [CVE-2025-48924](https://advisories.opensearch.org/advisories/CVE-2025-48924) and [CVE-2025-8916](https://advisories.opensearch.org/advisories/CVE-2025-8916)

### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md).
- [ ] Commits are signed per the DCO using `--signoff`.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/performance-analyzer/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
