### PR TITLE
Bump performance-analyzer-commons to v2.1.1

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -16,7 +16,7 @@ buildscript {
 
         // The PA Commons (https://github.com/opensearch-project/performance-analyzer-commons)
         // is a library dependency with hardcoded versioning in PA and RCA repos.
-        paCommonsVersion = "2.0.0"
+        paCommonsVersion = "2.1.1"
 
         // 3.0.0-SNAPSHOT -> 3.0.0.0-SNAPSHOT
         version_tokens = opensearch_version.tokenize('-')
@@ -26,7 +26,7 @@ buildscript {
         }
         if (isSnapshot) {
             opensearch_build += "-SNAPSHOT"
-            //paCommonsVersion += "-SNAPSHOT"
+            paCommonsVersion += "-SNAPSHOT"
 
         }
     }
@@ -272,6 +272,7 @@ dependencies {
 
     def junitVersion = "${versions.junit}"
     def jacksonVersion = "${versions.jackson}"
+    def jacksonAnnotationsVersion = "${versions.jackson_annotations}"
     def jacksonDataBindVersion = "${versions.jackson_databind}"
     def guavaVersion = "${versions.guava}"
 
@@ -292,7 +293,7 @@ dependencies {
         incoming.beforeResolve {
             resolutionStrategy {
                 force "junit:junit:${junitVersion}"
-                force "com.fasterxml.jackson.core:jackson-annotations:${jacksonVersion}"
+                force "com.fasterxml.jackson.core:jackson-annotations:${jacksonAnnotationsVersion}"
                 force "com.fasterxml.jackson.core:jackson-core:${jacksonVersion}"
                 force "com.fasterxml.jackson.core:jackson-databind:${jacksonDataBindVersion}"
                 force "com.fasterxml.jackson.module:jackson-module-paranamer:${jacksonVersion}"

--- a/release-notes/opensearch-performance-analyzer.release-notes-3.5.0.0.md
+++ b/release-notes/opensearch-performance-analyzer.release-notes-3.5.0.0.md
@@ -1,0 +1,10 @@
+## Version 3.5.0 Release Notes
+
+Compatible with OpenSearch and OpenSearch Dashboards version 3.5.0
+
+### Maintenance
+* Consuming performance-analyzer-commons 2.1.1 on JDK21 with all versions bumped for OpenSearch 3.5 release. Takes in the following changes for 3.5 release.
+    - https://github.com/opensearch-project/performance-analyzer-commons/pull/116 
+    - https://github.com/opensearch-project/performance-analyzer-commons/pull/117
+
+* Jackson core and annotations have different minor versions in OpenSearch-3.5.0 snapshot. Since we're using the same variable for both, build fails with invalid version. Using the version as per 3.5 snapshot.


### PR DESCRIPTION
### Description
1. Consuming performance-analyzer-commons 2.1.1 on JDK21 with all versions bumped for OpenSearch 3.5 release. Takes in the following changes for 3.5 release.
    - https://github.com/opensearch-project/performance-analyzer-commons/pull/116 
    - https://github.com/opensearch-project/performance-analyzer-commons/pull/117

2. Jackson core and annotations have different minor versions in OpenSearch-3.5.0 snapshot. Since we're using the same variable for both, build fails with invalid version. Using the version as per 3.5 snapshot.

### Related Issues
Resolves #[Issue number to be closed when this PR is merged]
<!-- List any other related issues here -->

### Check List
- [ ] New functionality includes testing.
- [x] New functionality has been documented.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md).
- [x] Commits are signed per the DCO using `--signoff`.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/performance-analyzer/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
