### PR TITLE
fix performance-analyzer-commons version to 2.1.0

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -16,7 +16,7 @@ buildscript {
 
         // The PA Commons (https://github.com/opensearch-project/performance-analyzer-commons)
         // is a library dependency with hardcoded versioning in PA and RCA repos.
-        paCommonsVersion = "2.1.1"
+        paCommonsVersion = "2.1.0"
 
         // 3.0.0-SNAPSHOT -> 3.0.0.0-SNAPSHOT
         version_tokens = opensearch_version.tokenize('-')

--- a/release-notes/opensearch-performance-analyzer.release-notes-3.5.0.0.md
+++ b/release-notes/opensearch-performance-analyzer.release-notes-3.5.0.0.md
@@ -3,8 +3,7 @@
 Compatible with OpenSearch and OpenSearch Dashboards version 3.5.0
 
 ### Maintenance
-* Consuming performance-analyzer-commons 2.1.1 on JDK21 with all versions bumped for OpenSearch 3.5 release. Takes in the following changes for 3.5 release.
-    - https://github.com/opensearch-project/performance-analyzer-commons/pull/116 
-    - https://github.com/opensearch-project/performance-analyzer-commons/pull/117
+* Consuming performance-analyzer-commons 2.1.0 on JDK21 with all versions bumped for OpenSearch 3.5 release. Takes in the following changes for 3.5 release.
+    - https://github.com/opensearch-project/performance-analyzer-commons/pull/118
 
 * Jackson core and annotations have different minor versions in OpenSearch-3.5.0 snapshot. Since we're using the same variable for both, build fails with invalid version. Using the version as per 3.5 snapshot.


### PR DESCRIPTION
### Description
fix performance-analyzer-commons version to 2.1.0. 

### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md).
- [ ] Commits are signed per the DCO using `--signoff`.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/performance-analyzer/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
