### PR TITLE
Add metric to count queries with script

### DIFF
--- a/src/main/java/org/opensearch/performanceanalyzer/action/PerformanceAnalyzerActionFilter.java
+++ b/src/main/java/org/opensearch/performanceanalyzer/action/PerformanceAnalyzerActionFilter.java
@@ -16,6 +16,7 @@ import org.opensearch.action.support.ActionFilterChain;
 import org.opensearch.common.inject.Inject;
 import org.opensearch.core.action.ActionListener;
 import org.opensearch.core.action.ActionResponse;
+import org.opensearch.performanceanalyzer.collectors.telemetry.RTFSearchRequestMetricsCollector;
 import org.opensearch.performanceanalyzer.commons.metrics.PerformanceAnalyzerMetrics;
 import org.opensearch.performanceanalyzer.commons.util.Util;
 import org.opensearch.performanceanalyzer.config.PerformanceAnalyzerController;
@@ -26,10 +27,12 @@ public class PerformanceAnalyzerActionFilter implements ActionFilter {
     private static AtomicLong uniqueID = new AtomicLong(0);
 
     private final PerformanceAnalyzerController controller;
+    private final RTFSearchRequestMetricsCollector rtfSearchRequestMetricsCollector;
 
     @Inject
     public PerformanceAnalyzerActionFilter(final PerformanceAnalyzerController controller) {
         this.controller = controller;
+        this.rtfSearchRequestMetricsCollector = new RTFSearchRequestMetricsCollector(controller);
     }
 
     @Override
@@ -73,9 +76,14 @@ public class PerformanceAnalyzerActionFilter implements ActionFilter {
                         RequestType.search.toString(),
                         id,
                         PerformanceAnalyzerMetrics.START_FILE_NAME);
+                rtfSearchRequestMetricsCollector.onSearchRequest(search);
                 chain.proceed(task, action, request, newListener);
                 return;
             }
+        }
+
+        if (request instanceof SearchRequest) {
+            rtfSearchRequestMetricsCollector.onSearchRequest((SearchRequest) request);
         }
 
         chain.proceed(task, action, request, listener);

--- a/src/main/java/org/opensearch/performanceanalyzer/collectors/telemetry/RTFSearchRequestMetricsCollector.java
+++ b/src/main/java/org/opensearch/performanceanalyzer/collectors/telemetry/RTFSearchRequestMetricsCollector.java
@@ -1,0 +1,142 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.performanceanalyzer.collectors.telemetry;
+
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.opensearch.action.search.SearchRequest;
+import org.opensearch.index.query.ScriptQueryBuilder;
+import org.opensearch.performanceanalyzer.OpenSearchResources;
+import org.opensearch.performanceanalyzer.commons.metrics.RTFMetrics;
+import org.opensearch.performanceanalyzer.commons.util.Util;
+import org.opensearch.performanceanalyzer.config.PerformanceAnalyzerController;
+import org.opensearch.search.aggregations.AggregationBuilder;
+import org.opensearch.search.aggregations.metrics.ScriptedMetricAggregationBuilder;
+import org.opensearch.search.builder.SearchSourceBuilder;
+import org.opensearch.search.sort.ScriptSortBuilder;
+import org.opensearch.telemetry.metrics.Counter;
+import org.opensearch.telemetry.metrics.MetricsRegistry;
+import org.opensearch.telemetry.metrics.tags.Tags;
+
+/**
+ * Collects per-request search metrics via the RTF telemetry pipeline. Currently tracks whether a
+ * search request contains a script (Painless, script_score, scripted_metric, etc.).
+ *
+ * <p>Metric emitted: {@code script_search_count} — incremented only when a script is detected.
+ */
+public class RTFSearchRequestMetricsCollector {
+
+    private static final Logger LOG = LogManager.getLogger(RTFSearchRequestMetricsCollector.class);
+
+    public static final String SCRIPT_SEARCH_COUNT = "script_search_count";
+
+    private final PerformanceAnalyzerController controller;
+    private Counter scriptSearchCounter;
+    private boolean metricsInitialized;
+
+    public RTFSearchRequestMetricsCollector(final PerformanceAnalyzerController controller) {
+        this.controller = controller;
+        this.metricsInitialized = false;
+    }
+
+    private void initializeMetricsIfNeeded(MetricsRegistry metricsRegistry) {
+        if (!metricsInitialized && metricsRegistry != null) {
+            scriptSearchCounter =
+                    metricsRegistry.createCounter(
+                            SCRIPT_SEARCH_COUNT,
+                            "Count of search requests that contain a script",
+                            RTFMetrics.MetricUnits.COUNT.toString());
+            metricsInitialized = true;
+        }
+    }
+
+    private boolean isEnabled() {
+        return controller.isPerformanceAnalyzerEnabled()
+                && (controller.getCollectorsRunModeValue() == Util.CollectorMode.DUAL.getValue()
+                        || controller.getCollectorsRunModeValue()
+                                == Util.CollectorMode.TELEMETRY.getValue());
+    }
+
+    /**
+     * Called on every incoming SearchRequest. Detects script usage and emits the counter via the
+     * RTF telemetry pipeline.
+     */
+    public void onSearchRequest(SearchRequest searchRequest) {
+        if (!isEnabled()) {
+            return;
+        }
+        MetricsRegistry metricsRegistry = OpenSearchResources.INSTANCE.getMetricsRegistry();
+        initializeMetricsIfNeeded(metricsRegistry);
+        if (scriptSearchCounter == null) {
+            LOG.debug("script_search_count counter not yet initialized, skipping");
+            return;
+        }
+        try {
+            if (detectScript(searchRequest)) {
+                scriptSearchCounter.add(1, Tags.create());
+            }
+        } catch (Exception e) {
+            LOG.debug("Error emitting script_search_count metric", e);
+        }
+    }
+
+    /**
+     * Detects common script patterns via direct type checks — no string serialization.
+     *
+     * <p>Detects:
+     * - Top-level script query: {"query": {"script": {...}}}
+     * - Script fields: {"script_fields": {...}}
+     * - Script sort: {"sort": {"_script": {...}}}
+     * - Scripted metric aggregation: {"aggs": {"x": {"scripted_metric": {...}}}}
+     *
+     * <p>Does NOT detect:
+     * - Scripts nested inside bool/dis_max/nested queries
+     * - Function score with script_score function
+     * - Bucket script / bucket selector pipeline aggregations
+     * - Scripts inside sub-aggregations
+     */
+    private boolean detectScript(SearchRequest searchRequest) {
+        if (searchRequest == null || searchRequest.source() == null) {
+            return false;
+        }
+        try {
+            SearchSourceBuilder source = searchRequest.source();
+
+            // Check top-level query type
+            if (source.query() instanceof ScriptQueryBuilder) {
+                return true;
+            }
+
+            // Check script fields
+            if (source.scriptFields() != null && !source.scriptFields().isEmpty()) {
+                return true;
+            }
+
+            // Check script sort
+            if (source.sorts() != null) {
+                for (var sort : source.sorts()) {
+                    if (sort instanceof ScriptSortBuilder) {
+                        return true;
+                    }
+                }
+            }
+
+            // Check top-level aggregations for scripted_metric
+            if (source.aggregations() != null) {
+                for (AggregationBuilder agg : source.aggregations().getAggregatorFactories()) {
+                    if (agg instanceof ScriptedMetricAggregationBuilder) {
+                        return true;
+                    }
+                }
+            }
+
+            return false;
+        } catch (Exception e) {
+            LOG.debug("Error detecting scripts in search request", e);
+            return false;
+        }
+    }
+}


### PR DESCRIPTION
### Description
This will emit metric script_search_count when script query is made.

Sample metric

`metric: ImmutableMetricData{resource=Resource{schemaUrl=null, attributes={service.name="OpenSearch"}}, instrumentationScopeInfo=InstrumentationScopeInfo{name=org.opensearch.telemetry, version=null, schemaUrl=null, attributes={}}, name=script_search_count, description=Count of search requests tagged by whether they contain a script, unit=count, type=DOUBLE_SUM, data=ImmutableSumData{points=[ImmutableDoublePointData{startEpochNanos=1773264920824685781, epochNanos=1773264980824673234, attributes={}, value=1.0, exemplars=[]}], monotonic=true, aggregationTemporality=DELTA}}`