### PR TITLE
Add returned doc count metric

### DIFF
--- a/src/main/java/org/opensearch/performanceanalyzer/PerformanceAnalyzerPlugin.java
+++ b/src/main/java/org/opensearch/performanceanalyzer/PerformanceAnalyzerPlugin.java
@@ -5,8 +5,6 @@
 
 package org.opensearch.performanceanalyzer;
 
-import static java.util.Collections.singletonList;
-
 import java.io.File;
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
@@ -40,6 +38,7 @@ import org.opensearch.env.Environment;
 import org.opensearch.env.NodeEnvironment;
 import org.opensearch.index.IndexModule;
 import org.opensearch.performanceanalyzer.action.PerformanceAnalyzerActionFilter;
+import org.opensearch.performanceanalyzer.action.RTFPerformanceAnalyzerActionFilter;
 import org.opensearch.performanceanalyzer.collectors.AdmissionControlMetricsCollector;
 import org.opensearch.performanceanalyzer.collectors.CacheConfigMetricsCollector;
 import org.opensearch.performanceanalyzer.collectors.CircuitBreakerCollector;
@@ -296,7 +295,9 @@ public final class PerformanceAnalyzerPlugin extends Plugin
     // - http level: bulk, search
     @Override
     public List<ActionFilter> getActionFilters() {
-        return singletonList(new PerformanceAnalyzerActionFilter(performanceAnalyzerController));
+        return Arrays.asList(
+                new PerformanceAnalyzerActionFilter(performanceAnalyzerController),
+                new RTFPerformanceAnalyzerActionFilter(performanceAnalyzerController));
     }
 
     @Override

--- a/src/main/java/org/opensearch/performanceanalyzer/action/RTFPerformanceAnalyzerActionFilter.java
+++ b/src/main/java/org/opensearch/performanceanalyzer/action/RTFPerformanceAnalyzerActionFilter.java
@@ -1,0 +1,74 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.performanceanalyzer.action;
+
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.opensearch.action.ActionRequest;
+import org.opensearch.action.search.SearchRequest;
+import org.opensearch.action.search.SearchResponse;
+import org.opensearch.action.support.ActionFilter;
+import org.opensearch.action.support.ActionFilterChain;
+import org.opensearch.core.action.ActionListener;
+import org.opensearch.core.action.ActionResponse;
+import org.opensearch.performanceanalyzer.collectors.telemetry.RTFSearchRequestMetricsCollector;
+import org.opensearch.performanceanalyzer.commons.util.Util;
+import org.opensearch.performanceanalyzer.config.PerformanceAnalyzerController;
+import org.opensearch.tasks.Task;
+
+/**
+ * RTF-specific {@link ActionFilter} that intercepts search responses and emits telemetry metrics
+ * via the RTF pipeline. Kept separate from {@link PerformanceAnalyzerActionFilter} which handles
+ * the RCA/event-queue pipeline.
+ */
+public class RTFPerformanceAnalyzerActionFilter implements ActionFilter {
+
+    private static final Logger LOG =
+            LogManager.getLogger(RTFPerformanceAnalyzerActionFilter.class);
+
+    private final PerformanceAnalyzerController controller;
+    private final RTFSearchRequestMetricsCollector rtfSearchRequestMetricsCollector;
+
+    public RTFPerformanceAnalyzerActionFilter(final PerformanceAnalyzerController controller) {
+        this.controller = controller;
+        this.rtfSearchRequestMetricsCollector = new RTFSearchRequestMetricsCollector(controller);
+    }
+
+    @Override
+    public <Request extends ActionRequest, Response extends ActionResponse> void apply(
+            Task task,
+            final String action,
+            Request request,
+            ActionListener<Response> listener,
+            ActionFilterChain<Request, Response> chain) {
+
+        if (request instanceof SearchRequest
+                && controller.isPerformanceAnalyzerEnabled()
+                && (controller.getCollectorsRunModeValue() == Util.CollectorMode.DUAL.getValue()
+                        || controller.getCollectorsRunModeValue()
+                                == Util.CollectorMode.TELEMETRY.getValue())) {
+            ActionListener<Response> wrappedListener =
+                    ActionListener.wrap(
+                            response -> {
+                                if (response instanceof SearchResponse) {
+                                    rtfSearchRequestMetricsCollector.onSearchResponse(
+                                            (SearchResponse) response);
+                                }
+                                listener.onResponse(response);
+                            },
+                            listener::onFailure);
+            chain.proceed(task, action, request, wrappedListener);
+            return;
+        }
+
+        chain.proceed(task, action, request, listener);
+    }
+
+    @Override
+    public int order() {
+        return Integer.MIN_VALUE + 1;
+    }
+}

--- a/src/main/java/org/opensearch/performanceanalyzer/collectors/telemetry/RTFSearchRequestMetricsCollector.java
+++ b/src/main/java/org/opensearch/performanceanalyzer/collectors/telemetry/RTFSearchRequestMetricsCollector.java
@@ -1,0 +1,82 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.performanceanalyzer.collectors.telemetry;
+
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.opensearch.action.search.SearchResponse;
+import org.opensearch.performanceanalyzer.OpenSearchResources;
+import org.opensearch.performanceanalyzer.commons.metrics.RTFMetrics;
+import org.opensearch.performanceanalyzer.commons.util.Util;
+import org.opensearch.performanceanalyzer.config.PerformanceAnalyzerController;
+import org.opensearch.telemetry.metrics.Histogram;
+import org.opensearch.telemetry.metrics.MetricsRegistry;
+import org.opensearch.telemetry.metrics.tags.Tags;
+
+/**
+ * Collects per-request search metrics via the RTF telemetry pipeline.
+ *
+ * <p>Metrics emitted:
+ *
+ * <ul>
+ *   <li>{@code search_doc_count} — histogram of documents returned per search response.
+ * </ul>
+ */
+public class RTFSearchRequestMetricsCollector {
+
+    private static final Logger LOG = LogManager.getLogger(RTFSearchRequestMetricsCollector.class);
+
+    public static final String SEARCH_DOC_COUNT = "search_doc_count";
+
+    private final PerformanceAnalyzerController controller;
+    private Histogram searchDocCountHistogram;
+    private boolean metricsInitialized;
+
+    public RTFSearchRequestMetricsCollector(final PerformanceAnalyzerController controller) {
+        this.controller = controller;
+        this.metricsInitialized = false;
+    }
+
+    private void initializeMetricsIfNeeded(MetricsRegistry metricsRegistry) {
+        if (!metricsInitialized && metricsRegistry != null) {
+            searchDocCountHistogram =
+                    metricsRegistry.createHistogram(
+                            SEARCH_DOC_COUNT,
+                            "Number of documents returned per search response",
+                            RTFMetrics.MetricUnits.COUNT.toString());
+            metricsInitialized = true;
+        }
+    }
+
+    public boolean isEnabled() {
+        return controller.isPerformanceAnalyzerEnabled()
+                && (controller.getCollectorsRunModeValue() == Util.CollectorMode.DUAL.getValue()
+                        || controller.getCollectorsRunModeValue()
+                                == Util.CollectorMode.TELEMETRY.getValue());
+    }
+
+    /**
+     * Called on every SearchResponse. Records the number of documents returned via the RTF
+     * telemetry pipeline.
+     */
+    public void onSearchResponse(SearchResponse searchResponse) {
+        if (!isEnabled()) {
+            return;
+        }
+        MetricsRegistry metricsRegistry = OpenSearchResources.INSTANCE.getMetricsRegistry();
+        initializeMetricsIfNeeded(metricsRegistry);
+        if (searchDocCountHistogram == null) {
+            LOG.debug("search_doc_count histogram not yet initialized, skipping");
+            return;
+        }
+        try {
+            int docCount = searchResponse.getHits().getHits().length;
+            searchDocCountHistogram.record(docCount, Tags.create());
+        } catch (Exception e) {
+            LOG.debug("Error emitting search_doc_count metric", e);
+        }
+    }
+}

--- a/src/test/java/org/opensearch/performanceanalyzer/PerformanceAnalyzerPluginTests.java
+++ b/src/test/java/org/opensearch/performanceanalyzer/PerformanceAnalyzerPluginTests.java
@@ -32,6 +32,7 @@ import org.opensearch.env.TestEnvironment;
 import org.opensearch.indices.breaker.BreakerSettings;
 import org.opensearch.indices.breaker.HierarchyCircuitBreakerService;
 import org.opensearch.performanceanalyzer.action.PerformanceAnalyzerActionFilter;
+import org.opensearch.performanceanalyzer.action.RTFPerformanceAnalyzerActionFilter;
 import org.opensearch.performanceanalyzer.config.setting.PerformanceAnalyzerClusterSettings;
 import org.opensearch.performanceanalyzer.http_action.config.PerformanceAnalyzerClusterConfigAction;
 import org.opensearch.performanceanalyzer.http_action.config.PerformanceAnalyzerConfigAction;
@@ -106,8 +107,9 @@ public class PerformanceAnalyzerPluginTests extends OpenSearchTestCase {
     @Test
     public void testGetActionFilters() {
         List<ActionFilter> list = plugin.getActionFilters();
-        assertEquals(1, list.size());
+        assertEquals(2, list.size());
         assertEquals(PerformanceAnalyzerActionFilter.class, list.get(0).getClass());
+        assertEquals(RTFPerformanceAnalyzerActionFilter.class, list.get(1).getClass());
     }
 
     @Test


### PR DESCRIPTION
This will emit metric for doc count returned for a search query when script query is made.


Sample Metric

[2026-03-18T13:18:07,399][WARN ][stderr                   ] [dev-dsk-gshhivam-1a-f8b252b1.eu-west-1.amazon.com] INFO: metric: ImmutableMetricData{resource=Resource{schemaUrl=null, attributes={service.name="OpenSearch"}}, instrumentationScopeInfo=InstrumentationScopeInfo{name=org.opensearch.telemetry, version=null, schemaUrl=null, attributes={}}, name=search_returned_doc_count, description=Actual number of documents returned per search response, unit=count, type=EXPONENTIAL_HISTOGRAM, data=ImmutableExponentialHistogramData{aggregationTemporality=DELTA, points=[ImmutableExponentialHistogramPointData{getStartEpochNanos=1773839827386629596, getEpochNanos=1773839887386622217, getAttributes={}, getScale=20, getSum=10.0, getCount=1, getZeroCount=0, hasMin=true, getMin=10.0, hasMax=true, getMax=10.0, getPositiveBuckets=DoubleExponentialHistogramBuckets{scale: 20, offset: 3483294, counts: {3483294=1} }, getNegativeBuckets=EmptyExponentialHistogramBuckets{scale=20, offset=0, bucketCounts=[], totalCount=0}, getExemplars=[]}]}}