### PR TITLE
Add shard_fetch_with_source_count metric

### DIFF
--- a/src/main/java/org/opensearch/performanceanalyzer/listener/RTFPerformanceAnalyzerSearchListener.java
+++ b/src/main/java/org/opensearch/performanceanalyzer/listener/RTFPerformanceAnalyzerSearchListener.java
@@ -25,6 +25,7 @@ import org.opensearch.performanceanalyzer.config.PerformanceAnalyzerController;
 import org.opensearch.performanceanalyzer.util.Utils;
 import org.opensearch.search.internal.SearchContext;
 import org.opensearch.tasks.Task;
+import org.opensearch.telemetry.metrics.Counter;
 import org.opensearch.telemetry.metrics.Histogram;
 import org.opensearch.telemetry.metrics.MetricsRegistry;
 import org.opensearch.telemetry.metrics.tags.Tags;
@@ -51,7 +52,10 @@ public class RTFPerformanceAnalyzerSearchListener
     private final Histogram cpuUtilizationHistogram;
     private final Histogram heapUsedHistogram;
     private final Histogram searchLatencyHistogram;
+    private final Counter querySourceHitsCounter;
     private final int numProcessors;
+
+    public static final String QUERY_SOURCE_HITS = "query_source_hits";
 
     public RTFPerformanceAnalyzerSearchListener(final PerformanceAnalyzerController controller) {
         this.controller = controller;
@@ -61,6 +65,8 @@ public class RTFPerformanceAnalyzerSearchListener
                 createHeapUsedHistogram(OpenSearchResources.INSTANCE.getMetricsRegistry());
         this.searchLatencyHistogram =
                 createSearchLatencyHistogram(OpenSearchResources.INSTANCE.getMetricsRegistry());
+        this.querySourceHitsCounter =
+                createQuerySourceHitsCounter(OpenSearchResources.INSTANCE.getMetricsRegistry());
         this.threadLocal = ThreadLocal.withInitial(HashMap::new);
         this.numProcessors = Runtime.getRuntime().availableProcessors();
     }
@@ -97,6 +103,18 @@ public class RTFPerformanceAnalyzerSearchListener
                     ShardOperationsValue.SHARD_SEARCH_LATENCY.toString(),
                     "Search latency per shard per phase",
                     RTFMetrics.MetricUnits.MILLISECOND.toString());
+        } else {
+            LOG.debug("MetricsRegistry is null");
+            return null;
+        }
+    }
+
+    private Counter createQuerySourceHitsCounter(MetricsRegistry metricsRegistry) {
+        if (metricsRegistry != null) {
+            return metricsRegistry.createCounter(
+                    QUERY_SOURCE_HITS,
+                    "Count of shard fetch phases where _source was requested",
+                    RTFMetrics.MetricUnits.COUNT.toString());
         } else {
             LOG.debug("MetricsRegistry is null");
             return null;
@@ -219,6 +237,9 @@ public class RTFPerformanceAnalyzerSearchListener
         searchLatencyHistogram.record(
                 fetchTimeInMills, createTags(searchContext, SHARD_FETCH_PHASE, false));
 
+        // Emit counter if _source was requested in this fetch phase
+        emitFetchWithSourceMetric(searchContext);
+
         addResourceTrackingCompletionListenerForFetchPhase(
                 searchContext, fetchStartTime, tookInNanos, SHARD_FETCH_PHASE, false);
     }
@@ -229,6 +250,23 @@ public class RTFPerformanceAnalyzerSearchListener
         long fetchTime = (System.nanoTime() - fetchStartTime);
         addResourceTrackingCompletionListenerForFetchPhase(
                 searchContext, fetchStartTime, fetchTime, SHARD_FETCH_PHASE, true);
+    }
+
+    /**
+     * Emits the query_source_hits counter if _source was requested in this fetch. Used to calculate
+     * source creation ratio: shard_search_rate / query_source_hits.
+     */
+    private void emitFetchWithSourceMetric(SearchContext searchContext) {
+        if (querySourceHitsCounter == null) {
+            return;
+        }
+        try {
+            if (searchContext.sourceRequested()) {
+                querySourceHitsCounter.add(1, createIndexTags(searchContext));
+            }
+        } catch (Exception e) {
+            LOG.error("Error emitting query_source_hits metric", e);
+        }
     }
 
     private void addResourceTrackingCompletionListener(
@@ -343,5 +381,15 @@ public class RTFPerformanceAnalyzerSearchListener
 
     private Tags createTags(SearchContext searchContext) {
         return createTags(searchContext, null, false);
+    }
+
+    private Tags createIndexTags(SearchContext searchContext) {
+        return Tags.create()
+                .addTag(
+                        RTFMetrics.CommonDimension.INDEX_NAME.toString(),
+                        searchContext.request().shardId().getIndex().getName())
+                .addTag(
+                        RTFMetrics.CommonDimension.INDEX_UUID.toString(),
+                        searchContext.request().shardId().getIndex().getUUID());
     }
 }

--- a/src/test/java/org/opensearch/performanceanalyzer/listener/RTFPerformanceAnalyzerSearchListenerTests.java
+++ b/src/test/java/org/opensearch/performanceanalyzer/listener/RTFPerformanceAnalyzerSearchListenerTests.java
@@ -13,6 +13,7 @@ import org.apache.commons.lang3.SystemUtils;
 import org.junit.Before;
 import org.junit.BeforeClass;
 import org.junit.Test;
+import org.mockito.ArgumentCaptor;
 import org.mockito.Mock;
 import org.mockito.Mockito;
 import org.opensearch.action.search.SearchShardTask;
@@ -29,6 +30,7 @@ import org.opensearch.performanceanalyzer.util.Utils;
 import org.opensearch.search.internal.SearchContext;
 import org.opensearch.search.internal.ShardSearchRequest;
 import org.opensearch.tasks.Task;
+import org.opensearch.telemetry.metrics.Counter;
 import org.opensearch.telemetry.metrics.Histogram;
 import org.opensearch.telemetry.metrics.MetricsRegistry;
 import org.opensearch.telemetry.metrics.tags.Tags;
@@ -48,6 +50,7 @@ public class RTFPerformanceAnalyzerSearchListenerTests {
     @Mock private Histogram searchLatencyHistogram;
     @Mock private Histogram shardMetricsCpuHistogram;
     @Mock private Histogram shardMetricsHeapHistogram;
+    @Mock private Counter querySourceHitsCounter;
     @Mock private Index index;
 
     @Mock private TaskResourceUsage taskResourceUsage;
@@ -89,6 +92,10 @@ public class RTFPerformanceAnalyzerSearchListenerTests {
                             }
                             return null;
                         });
+        Mockito.when(
+                        metricsRegistry.createCounter(
+                                Mockito.anyString(), Mockito.anyString(), Mockito.anyString()))
+                .thenReturn(querySourceHitsCounter);
         searchListener = new RTFPerformanceAnalyzerSearchListener(controller);
         assertEquals(
                 RTFPerformanceAnalyzerSearchListener.class.getSimpleName(),
@@ -201,6 +208,101 @@ public class RTFPerformanceAnalyzerSearchListenerTests {
         Mockito.verify(heapUsedHistogram).record(Mockito.anyDouble(), Mockito.any(Tags.class));
         Mockito.verify(shardCpu).record(Mockito.anyDouble(), Mockito.any(Tags.class));
         Mockito.verify(shardHeap).record(Mockito.anyDouble(), Mockito.any(Tags.class));
+    }
+
+    @Test
+    public void testFetchPhaseEmitsQuerySourceHitsWhenSourceRequested() {
+        initializeValidSearchContext(true);
+        Mockito.when(controller.getCollectorsRunModeValue())
+                .thenReturn(Util.CollectorMode.TELEMETRY.getValue());
+        Mockito.when(shardId.getIndex()).thenReturn(index);
+        Mockito.when(index.getName()).thenReturn("myTestIndex");
+        Mockito.when(index.getUUID()).thenReturn("abc-def");
+        Mockito.when(searchContext.sourceRequested()).thenReturn(true);
+
+        searchListener.preFetchPhase(searchContext);
+        searchListener.fetchPhase(searchContext, 0L);
+
+        Mockito.verify(querySourceHitsCounter).add(Mockito.eq(1L), Mockito.any(Tags.class));
+    }
+
+    @Test
+    public void testFetchPhaseDoesNotEmitQuerySourceHitsWhenSourceNotRequested() {
+        initializeValidSearchContext(true);
+        Mockito.when(controller.getCollectorsRunModeValue())
+                .thenReturn(Util.CollectorMode.TELEMETRY.getValue());
+        Mockito.when(shardId.getIndex()).thenReturn(index);
+        Mockito.when(index.getName()).thenReturn("myTestIndex");
+        Mockito.when(index.getUUID()).thenReturn("abc-def");
+        Mockito.when(searchContext.sourceRequested()).thenReturn(false);
+
+        searchListener.preFetchPhase(searchContext);
+        searchListener.fetchPhase(searchContext, 0L);
+
+        Mockito.verify(querySourceHitsCounter, Mockito.never())
+                .add(Mockito.anyLong(), Mockito.any(Tags.class));
+    }
+
+    @Test
+    public void testQuerySourceHitsCounterNotCreatedWhenMetricsRegistryNull() {
+        OpenSearchResources.INSTANCE.setMetricsRegistry(null);
+        RTFPerformanceAnalyzerSearchListener listener =
+                new RTFPerformanceAnalyzerSearchListener(controller);
+
+        // Should not throw even with null counter — emitFetchWithSourceMetric guards against it
+        initializeValidSearchContext(true);
+        Mockito.when(controller.getCollectorsRunModeValue())
+                .thenReturn(Util.CollectorMode.TELEMETRY.getValue());
+        Mockito.when(shardId.getIndex()).thenReturn(index);
+        Mockito.when(index.getName()).thenReturn("myTestIndex");
+        Mockito.when(index.getUUID()).thenReturn("abc-def");
+
+        listener.preFetchPhase(searchContext);
+        listener.fetchPhase(searchContext, 0L);
+
+        // Restore for other tests
+        OpenSearchResources.INSTANCE.setMetricsRegistry(metricsRegistry);
+    }
+
+    @Test
+    public void testQuerySourceHitsHandlesExceptionGracefully() {
+        initializeValidSearchContext(true);
+        Mockito.when(controller.getCollectorsRunModeValue())
+                .thenReturn(Util.CollectorMode.TELEMETRY.getValue());
+        Mockito.when(shardId.getIndex()).thenReturn(index);
+        Mockito.when(index.getName()).thenReturn("myTestIndex");
+        Mockito.when(index.getUUID()).thenReturn("abc-def");
+        Mockito.when(searchContext.sourceRequested())
+                .thenThrow(new RuntimeException("simulated failure"));
+
+        // Should not propagate — catch block logs error and swallows
+        searchListener.preFetchPhase(searchContext);
+        searchListener.fetchPhase(searchContext, 0L);
+
+        Mockito.verify(querySourceHitsCounter, Mockito.never())
+                .add(Mockito.anyLong(), Mockito.any(Tags.class));
+    }
+
+    @Test
+    public void testQuerySourceHitsEmitsCorrectTags() {
+        initializeValidSearchContext(true);
+        Mockito.when(controller.getCollectorsRunModeValue())
+                .thenReturn(Util.CollectorMode.TELEMETRY.getValue());
+        Mockito.when(shardId.getIndex()).thenReturn(index);
+        Mockito.when(index.getName()).thenReturn("myTestIndex");
+        Mockito.when(index.getUUID()).thenReturn("abc-def");
+        Mockito.when(searchContext.sourceRequested()).thenReturn(true);
+
+        searchListener.preFetchPhase(searchContext);
+        searchListener.fetchPhase(searchContext, 0L);
+
+        ArgumentCaptor<Tags> tagsCaptor = ArgumentCaptor.forClass(Tags.class);
+        Mockito.verify(querySourceHitsCounter).add(Mockito.eq(1L), tagsCaptor.capture());
+
+        Tags capturedTags = tagsCaptor.getValue();
+        String tagsString = capturedTags.toString();
+        assertTrue("Tags should contain index name", tagsString.contains("myTestIndex"));
+        assertTrue("Tags should contain index UUID", tagsString.contains("abc-def"));
     }
 
     private void initializeValidSearchContext(boolean isValid) {


### PR DESCRIPTION
### Description
Add shard_fetch_with_source_count metric. This will emit a counter on fetch phase when source is requested.

ImmutableMetricData{resource=Resource{schemaUrl=null, attributes={service.name="OpenSearch"}}, instrumentationScopeInfo=InstrumentationScopeInfo{name=org.opensearch.telemetry, version=null, schemaUrl=null, attributes={}}, name=shard_fetch_with_source_count, description=Count of shard fetch phases where _source was requested, unit=count, type=DOUBLE_SUM, data=ImmutableSumData{points=[ImmutableDoublePointData{startEpochNanos=1774959167219102530, epochNanos=1774959227218847618, attributes={index_name="test-index", index_uuid="LlP0tKOESyi5Bq7IVi0sDw", shard_id=0}, value=1.0, exemplars=[]}], monotonic=true, aggregationTemporality=DELTA}}
