### PR TITLE
Fix CVE-2025-68161: Force resolve log4j dependencies

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -304,8 +304,8 @@ dependencies {
                 force "org.slf4j:slf4j-api:2.0.0"
                 force "org.apache.bcel:bcel:6.6.0" // This line should be removed once Spotbugs is upgraded to 4.7.4
                 force "com.google.guava:guava:${guavaVersion}"
-                force "org.apache.logging.log4j:log4j-core:${log4jVersion}" // CVE-2025-68161
-                force "org.apache.logging.log4j:log4j-api:${log4jVersion}" // CVE-2025-68161
+                force "org.apache.logging.log4j:log4j-core:${log4jVersion}"
+                force "org.apache.logging.log4j:log4j-api:${log4jVersion}"
             }
         }
     }

--- a/build.gradle
+++ b/build.gradle
@@ -304,6 +304,8 @@ dependencies {
                 force "org.slf4j:slf4j-api:2.0.0"
                 force "org.apache.bcel:bcel:6.6.0" // This line should be removed once Spotbugs is upgraded to 4.7.4
                 force "com.google.guava:guava:${guavaVersion}"
+                force "org.apache.logging.log4j:log4j-core:${log4jVersion}" // CVE-2025-68161
+                force "org.apache.logging.log4j:log4j-api:${log4jVersion}" // CVE-2025-68161
             }
         }
     }
@@ -322,8 +324,6 @@ dependencies {
     implementation "com.fasterxml.jackson.core:jackson-annotations:${jacksonVersion}"
     implementation "com.fasterxml.jackson.core:jackson-databind:${jacksonDataBindVersion}"
     implementation "com.fasterxml.jackson.module:jackson-module-paranamer:${jacksonVersion}"
-    implementation(group: 'org.apache.logging.log4j', name: 'log4j-api', version: "${log4jVersion}")
-    implementation(group: 'org.apache.logging.log4j', name: 'log4j-core', version: "${log4jVersion}")
     implementation("com.google.guava:guava:${guavaVersion}") {
         version {
             strictly "${guavaVersion}"


### PR DESCRIPTION
### Description
Fix CVE-2025-68161: Force resolve log4j dependencies

### Related Issues
Resolves https://advisories.opensearch.org/advisories/CVE-2025-68161

### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md).
- [ ] Commits are signed per the DCO using `--signoff`.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/performance-analyzer/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
