### PR TITLE
Fix CVE-2025-67030: Pin org.codehaus.plexus:plexus-utils to 4.0.2

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -306,6 +306,7 @@ dependencies {
                 force "com.google.guava:guava:${guavaVersion}"
                 force "org.apache.logging.log4j:log4j-core:${log4jVersion}"
                 force "org.apache.logging.log4j:log4j-api:${log4jVersion}"
+                force "org.codehaus.plexus:plexus-utils:4.0.2"
             }
         }
     }


### PR DESCRIPTION
### Description
Fix CVE-2025-67030: Pin org.codehaus.plexus:plexus-utils to 4.0.2
CVE: https://advisories.opensearch.org/advisory/CVE-2025-67030

### Related Issues
Resolves #[Issue number to be closed when this PR is merged]
<!-- List any other related issues here -->

### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md).
- [ ] Commits are signed per the DCO using `--signoff`.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/performance-analyzer/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
