### PR TITLE
Bump plexus-utils from 4.0.2 to 4.0.3

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -296,7 +296,7 @@ dependencies {
             force "org.apache.commons:commons-lang3:${versions.commonslang}"
             force "org.slf4j:slf4j-api:2.0.0"
             force "com.google.guava:guava:${guavaVersion}"
-            force "org.codehaus.plexus:plexus-utils:4.0.2"
+            force "org.codehaus.plexus:plexus-utils:4.0.3"
             force "org.apache.httpcomponents:httpcore:${versions.httpcore}"
             force "commons-codec:commons-codec:${versions.commonscodec}"
             force "io.netty:netty-codec-http2:${nettyVersion}"


### PR DESCRIPTION
### Description
Fix CVE-2025-67030: bump plexus-utils from 4.0.2 to 4.0.3


### Related Issues
Resolves #[Issue number to be closed when this PR is merged]
<!-- List any other related issues here -->

### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md).
- [ ] Commits are signed per the DCO using `--signoff`.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/performance-analyzer/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
