### PR TITLE
[Backport 2.19] Update maven2 mirror repository url order

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -34,8 +34,9 @@ buildscript {
     // Used to resolve build file dependencies
     repositories {
         mavenLocal()
-        maven { url "https://ci.opensearch.org/ci/dbc/snapshots/maven/" }
+        maven { url "https://ci.opensearch.org/maven2/" }
         mavenCentral()
+        maven { url "https://ci.opensearch.org/ci/dbc/snapshots/maven/" }
         maven { url "https://plugins.gradle.org/m2/" }
     }
 
@@ -198,8 +199,9 @@ publishing {
 
 repositories {
     mavenLocal()
-    maven { url "https://ci.opensearch.org/ci/dbc/snapshots/maven/" }
+    maven { url "https://ci.opensearch.org/maven2/" }
     mavenCentral()
+    maven { url "https://ci.opensearch.org/ci/dbc/snapshots/maven/" }
     maven { url "https://plugins.gradle.org/m2/" }
 }
 


### PR DESCRIPTION
### Description
[Backport 2.19] Update maven2 mirror repository url order

### Issues Resolved
https://github.com/opensearch-project/opensearch-build/issues/6050

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).