### PR TITLE
Increment version to 3.8.0-SNAPSHOT

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -6,7 +6,7 @@
 buildscript {
 
     ext {
-        opensearch_version = System.getProperty("opensearch.version", "3.7.0-SNAPSHOT")
+        opensearch_version = System.getProperty("opensearch.version", "3.8.0-SNAPSHOT")
         isSnapshot = "true" == System.getProperty("build.snapshot", "true")
         buildVersionQualifier = System.getProperty("build.version_qualifier", "")
 

--- a/src/main/java/org/opensearch/performanceanalyzer/transport/PerformanceAnalyzerTransportChannel.java
+++ b/src/main/java/org/opensearch/performanceanalyzer/transport/PerformanceAnalyzerTransportChannel.java
@@ -99,6 +99,11 @@ public class PerformanceAnalyzerTransportChannel implements TransportChannel, Me
     }
 
     @Override
+    public boolean isCancelled() {
+        return this.original != null && this.original.isCancelled();
+    }
+
+    @Override
     public void sendResponse(TransportResponse response) throws IOException {
         emitMetricsFinish(null);
         original.sendResponse(response);


### PR DESCRIPTION
### Description
Incremented version to 3.8.0-SNAPSHOT.


Also fix the build - 
OpenSearch PR #22359 adds a default `isCancelled()` method to `TransportChannel` (the cross-cluster streaming transport). `PerformanceAnalyzerTransportChannel` wraps a `TransportChannel` and delegates every overridable method. Without this override, the reflective delegation test (`testPAChannelDelegatesToOriginal`) fails: the interface default returns `false` without touching the wrapped channel, so `verify(spy).isCancelled()` fails.

The other streaming defaults added by #22359 (`sendResponseBatch`, `completeStream`) throw `UnsupportedOperationException`, which the test explicitly skips — only `isCancelled()` returns silently, so it alone needs an override.

This PR also folds in the OpenSearch `3.8.0-SNAPSHOT` version bump from #949. The bump is what pulls in the `TransportChannel` carrying `isCancelled()`, so the two changes are coupled: #949 on its own fails CI (the delegation test breaks without this override), and this override on `3.7.0-SNAPSHOT` is a harmless no-op of a method the interface does not yet have. Combining them keeps the branch self-consistent and lets **#949 be closed**.

### Fix

- Override `isCancelled()` with a null-safe delegation to the wrapped channel — the same pattern as the existing `getVersion()` / `get()` overrides.
- Bump `opensearch_version` default to `3.8.0-SNAPSHOT`.

### Testing

Verified locally against `3.8.0-SNAPSHOT`: `compileJava` / `compileTestJava` pass, and the resolved `opensearch-3.8.0-SNAPSHOT.jar` confirms `TransportChannel` now declares `public default boolean isCancelled()`, so the `@Override` binds to it. `testPAChannelDelegatesToOriginal` reflectively exercises the new override on Linux CI (the test suite is Linux-only via `assumeTrue(IS_OS_LINUX)`).

### Issues Resolved

Supersedes #949. Fixes compatibility with opensearch-project/OpenSearch#22359.

### Check List
- [x] New functionality includes testing
- [x] Commits are signed (`Signed-off-by`)
