### PR TITLE
fix(deps): Bump plexus-utils to 4.0.3 to fix CVE-2025-67030

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -308,7 +308,7 @@ dependencies {
                 force "com.google.guava:guava:${guavaVersion}"
                 force "org.apache.logging.log4j:log4j-core:${log4jVersion}"
                 force "org.apache.logging.log4j:log4j-api:${log4jVersion}"
-                force "org.codehaus.plexus:plexus-utils:4.0.2"
+                force "org.codehaus.plexus:plexus-utils:4.0.3"
             }
         }
     }


### PR DESCRIPTION
Upgrade the forced version of org.codehaus.plexus:plexus-utils from 4.0.2 to 4.0.3 in the resolution strategy to remediate CVE-2025-67030, a directory traversal vulnerability in the extractFile method of org.codehaus.plexus.util.Expand.

This dependency is only present on the checkstyle build-tooling classpath (not shipped in the plugin runtime), but is bumped as a supply-chain hygiene measure.

### Description
[Describe what this change achieves]

### Related Issues
Resolves #[Issue number to be closed when this PR is merged]
<!-- List any other related issues here -->

### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md).
- [ ] Commits are signed per the DCO using `--signoff`.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/performance-analyzer/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
