### PR TITLE
Add ci.opensearch.org/m2/ mirror for plugin resolution (performance-analyzer)

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -34,8 +34,8 @@ buildscript {
     // Used to resolve build file dependencies
     repositories {
         mavenLocal()
-        maven { url = "https://ci.opensearch.org/m2/" }
         maven { url = "https://ci.opensearch.org/maven2/" }
+        maven { url = "https://ci.opensearch.org/m2/" }
         maven { url = "https://ci.opensearch.org/ci/dbc/snapshots/maven/" }
         mavenCentral()
         maven { url = "https://plugins.gradle.org/m2/" }
@@ -205,8 +205,8 @@ publishing {
 
 repositories {
     mavenLocal()
-    maven { url "https://ci.opensearch.org/m2/" }
     maven { url "https://ci.opensearch.org/maven2/" }
+    maven { url "https://ci.opensearch.org/m2/" }
     maven { url "https://ci.opensearch.org/ci/dbc/snapshots/maven/" }
     mavenCentral()
     maven { url "https://plugins.gradle.org/m2/" }

--- a/build.gradle
+++ b/build.gradle
@@ -34,6 +34,7 @@ buildscript {
     // Used to resolve build file dependencies
     repositories {
         mavenLocal()
+        maven { url = "https://ci.opensearch.org/m2/" }
         maven { url = "https://ci.opensearch.org/maven2/" }
         maven { url = "https://ci.opensearch.org/ci/dbc/snapshots/maven/" }
         mavenCentral()
@@ -204,6 +205,7 @@ publishing {
 
 repositories {
     mavenLocal()
+    maven { url "https://ci.opensearch.org/m2/" }
     maven { url "https://ci.opensearch.org/maven2/" }
     maven { url "https://ci.opensearch.org/ci/dbc/snapshots/maven/" }
     mavenCentral()

--- a/settings.gradle
+++ b/settings.gradle
@@ -1,7 +1,7 @@
 pluginManagement {
     repositories {
-        maven { url = "https://ci.opensearch.org/m2/" }
         maven { url = "https://ci.opensearch.org/maven2/" }
+        maven { url = "https://ci.opensearch.org/m2/" }
         gradlePluginPortal()
         mavenCentral()
     }

--- a/settings.gradle
+++ b/settings.gradle
@@ -1,5 +1,6 @@
 pluginManagement {
     repositories {
+        maven { url = "https://ci.opensearch.org/m2/" }
         maven { url = "https://ci.opensearch.org/maven2/" }
         gradlePluginPortal()
         mavenCentral()


### PR DESCRIPTION
### Description
Add ci.opensearch.org/m2/ mirror for plugin resolution (performance-analyzer)

### Issues Resolved
https://github.com/opensearch-project/opensearch-build/issues/6278#issuecomment-5135909975

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).